### PR TITLE
Use new Sentry vm

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -52,7 +52,7 @@ Future<void> main() async {
     // Initialize Sentry.
     await SentryFlutter.init((options) {
       // Our Sentry uses an on-premise installation.
-      options.dsn = "https://d2ab503d9cb6409aba03cac4cfa4a01c@priobike.vkw.tu-dresden.de/2";
+      options.dsn = "https://f794ea046ecf420fb65b5964b3edbf53@priobike-sentry.inf.tu-dresden.de/2";
     });
 
     // Load offline map tiles.


### PR DESCRIPTION
@PaulPickhardt @adeveloper-wq could one of you check this, e.g. by logging into [Sentry](https://priobike-sentry.inf.tu-dresden.de/organizations/sentry/projects/flutter/?project=2) with the credentials in the [org](https://github.com/priobike) and trigger an error?