### PR TITLE
Fix darkmode for license view and made app bar at logging view less android-like

### DIFF
--- a/lib/licenses/views.dart
+++ b/lib/licenses/views.dart
@@ -19,11 +19,8 @@ class LicenseView extends StatelessWidget {
     return Theme(
       data: Theme.of(context).copyWith(
         appBarTheme: const AppBarTheme(
-          backgroundColor: Colors.white,
           elevation: 0,
-          centerTitle: false,
-          titleTextStyle: TextStyle(color: Colors.black, fontSize: 20),
-          iconTheme: IconThemeData(color: Colors.black),
+          titleTextStyle: TextStyle(fontSize: 20),
         ),
       ),
       child: LicensePage(

--- a/lib/logging/views.dart
+++ b/lib/logging/views.dart
@@ -19,6 +19,8 @@ class LogsViewState extends State<LogsView> {
       child: Scaffold(
         appBar: AppBar(
           title: const Text("Logs"),
+          elevation: 0,
+          titleTextStyle: const TextStyle(fontSize: 20),
           actions: [
             IconButton(
               icon: const Icon(Icons.share),


### PR DESCRIPTION
The latter also makes the app bars in the license view and the logging view look the same (those are the only two pages that use the classic app bar). Making it less Android-like is achieved by removing the elevation which is a classic material design property.

Corresponding ticket: https://trello.com/c/a17xheSv/365-unterst%C3%BCtzung-des-darkmodes-f%C3%BCr-die-licenses-appbar