### PR TITLE
Add stretch overscroll for usage of app at android version >= 12

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,6 +1,5 @@
 import 'dart:async';
 
-import 'package:device_info_plus/device_info_plus.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart' hide Feedback, Shortcuts;
 import 'package:priobike/accelerometer/services/accelerometer.dart';


### PR DESCRIPTION
For Android-versions < 12 the old glow-overscroll is still used to stay consistent with the standard design of the respective versions. Tested on a real device with Android-version 12 and on an emulator with Android-version 11.

Corresponding ticket: https://trello.com/c/nB5gD26q/362-nutzung-von-stretch-anstelle-von-glow-beim-overscroll-bei-android