### PR TITLE
Fix elevation profile chart axes

### DIFF
--- a/lib/routing/views/charts/height.dart
+++ b/lib/routing/views/charts/height.dart
@@ -80,8 +80,6 @@ class RouteHeightChartState extends State<RouteHeightChart> {
 
     processRouteData();
 
-    final frame = MediaQuery.of(context);
-
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 8),
       child: Column(


### PR DESCRIPTION
- added description for y-axis ("Höhe in Meter")
- allowed decimal numbers for x-axis ticks (before only whole numbers were allowed and therefore for routes with a distance below 1 km no ticks on the x-axis and therefore no distance was shown in the height profile)