### PR TITLE
Replaced ModalBottomSheet with AlertDialog for Homescreen Stats

### DIFF
--- a/lib/statistics/views/total.dart
+++ b/lib/statistics/views/total.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:priobike/common/layout/buttons.dart';
-import 'package:priobike/common/layout/modal.dart';
 import 'package:priobike/common/layout/spacing.dart';
 import 'package:priobike/common/layout/text.dart';
 import 'package:priobike/statistics/services/statistics.dart';


### PR DESCRIPTION
I have replaced the ModalBottomSheet with AlertDialogs for State at the bottom of the Homescreen, because the ModalBottomSheet was unnecessarily big for the amount of text it displayed. 

See here for Trello: https://trello.com/c/6SToovMF

I've tried to be consistent with the Theme of the whole app. 

What do you think?

## Old
<p float="left">
<img width="170" alt="image" src="https://user-images.githubusercontent.com/89537082/204572953-4d6ff5f7-e730-4e18-814c-43548386de0c.png"> 
<img width="170" alt="image" src="https://user-images.githubusercontent.com/89537082/204572978-969c4e92-13a9-4b61-bd73-559c24070740.png">
<img width="170" alt="image" src="https://user-images.githubusercontent.com/89537082/204572827-d58482d2-45b7-4cc5-86fb-1013f8cac838.png">
<img width="170" alt="image" src="https://user-images.githubusercontent.com/89537082/204572861-786e139e-0e3b-4cb4-83d9-917a37ba9df3.png">
</p>


## New
<p float="left">
<img width="170" alt="image" src="https://user-images.githubusercontent.com/89537082/204571183-4e35d766-bab2-49ea-8e73-c6d39e151d77.png">
<img width="170" alt="image" src="https://user-images.githubusercontent.com/89537082/204571276-ef93af3e-3cb9-4eea-b317-7417587146c5.png">
<img width="170" alt="image" src="https://user-images.githubusercontent.com/89537082/204572522-b1dd061f-bf9b-4881-bfef-65d7a3d18c13.png">
<img width="170" alt="image" src="https://user-images.githubusercontent.com/89537082/204572602-860e25c3-5ab2-4c1d-85dc-98818ea896fc.png">
</p>

