### PR TITLE
Disable option to Remove Tracking for Testing

### DIFF
--- a/lib/feedback/views/main.dart
+++ b/lib/feedback/views/main.dart
@@ -9,7 +9,6 @@ import 'package:priobike/logging/toast.dart';
 import 'package:priobike/routing/views/main.dart';
 import 'package:priobike/statistics/services/statistics.dart';
 import 'package:priobike/tracking/services/tracking.dart';
-import 'package:priobike/tracking/views/send.dart';
 import 'package:provider/provider.dart';
 
 class FeedbackView extends StatefulWidget {
@@ -220,6 +219,9 @@ class FeedbackViewState extends State<FeedbackView> {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.center,
       children: [
+        const VSpace(),
+        const Divider(),
+        const VSpace(),
         Padding(
           padding: const EdgeInsets.symmetric(horizontal: 32),
           child: Small(text: "Hat dir die Route gefallen?", context: context),
@@ -256,28 +258,6 @@ class FeedbackViewState extends State<FeedbackView> {
     );
   }
 
-  Widget renderSendTracking() {
-    // Originally we had a checkbox here, to enable/disable tracking
-    // but until we release the app to the public we removed the option to disable tracking
-
-    tracking.setWillSendTrack(true);
-    return Container();
-
-    // ignore: dead_code
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.center,
-      children: const [
-        Padding(
-          padding: EdgeInsets.symmetric(horizontal: 32),
-          child: SendTrackingView(),
-        ),
-        VSpace(),
-        Divider(),
-        VSpace(),
-      ],
-    );
-  }
-
   Widget renderSendButton() {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.center,
@@ -285,9 +265,7 @@ class FeedbackViewState extends State<FeedbackView> {
         BigButton(
           iconColor: Colors.white,
           icon: Icons.check,
-          //feedback.willSendFeedback || (tracking.willSendTrack && tracking.canSendTrack) ? Icons.send : Icons.check,
-          label:
-              "Fertig", //feedback.willSendFeedback || (tracking.willSendTrack && tracking.canSendTrack) ? "Senden" : "Fertig",
+          label: "Fertig",
           onPressed: () => submit(context),
         ),
         const VSpace(),
@@ -331,7 +309,6 @@ class FeedbackViewState extends State<FeedbackView> {
                       renderFeedback(),
                       if (!widget.isolatedViewUsage) ...[
                         renderSummary(),
-                        renderSendTracking(),
                         renderSaveRoute(),
                       ],
                       renderSendButton(),

--- a/lib/tracking/services/tracking.dart
+++ b/lib/tracking/services/tracking.dart
@@ -138,7 +138,8 @@ class Tracking with ChangeNotifier {
 
   /// Set the willSend flag.
   void setWillSendTrack(bool willSendTrack) {
-    this.willSendTrack = willSendTrack;
+    // Note: At the moment, this does nothing since the user cannot change this setting.
+    this.willSendTrack = true;
     notifyListeners();
   }
 


### PR DESCRIPTION
See: https://trello.com/c/LSgxXQqQ

@PhilippMatthes Should we keep the old code so we can later easily readd the option to disable tracking?