### PR TITLE
Reset alerts when leaving the routing view

### DIFF
--- a/lib/status/services/sg.dart
+++ b/lib/status/services/sg.dart
@@ -124,6 +124,10 @@ class PredictionSGStatus with ChangeNotifier {
   /// Reset the status.
   Future<void> reset() async {
     cache = {};
+    offline = 0;
+    bad = 0;
+    disconnected = 0;
+    ok = 0;
     isLoading = false;
     notifyListeners();
   }


### PR DESCRIPTION
Done by setting the counters for _offline_, _bad_, _disconnected_ and _ok_ sgs to zero again when resetting the `PredictionSGStatus`-service.

Corresponding ticket: https://trello.com/c/MF2K4NDO/346-alerts-von-vorangegangenem-routing-werden-beim-%C3%B6ffnen-des-freien-routings-dargestellt