### PR TITLE
Optimize map layers and mitigate issues with async display on iOS

### DIFF
--- a/lib/common/map/layers.dart
+++ b/lib/common/map/layers.dart
@@ -100,36 +100,22 @@ class AllRoutesLayer {
 
 class SelectedRouteLayer {
   /// The features to display.
-  final List<dynamic> features = List.filled(1, null, growable: false); // For optmization.
+  final List<dynamic> features = List.empty(growable: true);
 
   SelectedRouteLayer(BuildContext context) {
     final routing = Provider.of<Routing>(context, listen: false);
     final route = routing.selectedRoute?.route ?? [];
-    final waypoints = routing.selectedWaypoints ?? [];
     final coordinates = route.map((e) => [e.lon, e.lat]).toList();
-    if (waypoints.length > 1) {
-      final geometry = {
-        "type": "LineString",
-        "coordinates": coordinates,
-      };
-      features[0] = {
-        "id": "selected-route",
-        "type": "Feature",
-        "properties": {},
-        "geometry": geometry,
-      };
-    } else {
-      final geometry = {
-        "type": "MultiPoint",
-        "coordinates": coordinates,
-      };
-      features[0] = {
-        "id": "selected-route",
-        "type": "Feature",
-        "properties": {},
-        "geometry": geometry,
-      };
-    }
+    final geometry = {
+      "type": "LineString",
+      "coordinates": coordinates,
+    };
+    features.add({
+      "id": "selected-route",
+      "type": "Feature",
+      "properties": {},
+      "geometry": geometry,
+    });
   }
 
   /// Install the overlay on the layer controller.
@@ -805,7 +791,7 @@ class ConstructionSitesLayer {
         iconImage: isDark ? "constructiondark" : "constructionlight",
         iconSize: iconSize,
         iconAllowOverlap: true,
-        iconOpacity: showAfter(zoom: 14),
+        iconOpacity: showAfter(zoom: 13),
         textHaloColor: isDark ? "#000000" : "#ffffff",
         textHaloWidth: 1,
         textOffset: [
@@ -817,7 +803,8 @@ class ConstructionSitesLayer {
         textSize: 12,
         textAnchor: "center",
         textColor: "#e67e22",
-        textOpacity: showAfter(zoom: 15),
+        textOpacity: showAfter(zoom: 13),
+        textAllowOverlap: true,
       ),
     );
   }
@@ -859,12 +846,13 @@ class AccidentHotspotsLayer {
           Expressions.literal,
           [0, 1]
         ],
-        textField: "Unfallschwerpunkt",
+        textField: "Unfall-\nschwerpunkt",
         textFont: ['DIN Offc Pro Medium', 'Arial Unicode MS Bold'],
         textSize: 12,
         textAnchor: "center",
         textColor: "#ff4757",
-        textOpacity: showAfter(zoom: 14),
+        textOpacity: showAfter(zoom: 13),
+        textAllowOverlap: true,
       ),
     );
   }


### PR DESCRIPTION
- Make accident hotspots and construction sites visible from zoom 13 instead of zoom 14/15
- Reformat "Unfallschwerpunkt" to linebreak after "Unfall"
- Allow construction site labels and accident hotspot labels to overlap
- Don't await `updateUserLocation` and mark this bug as a NOTE
- Make sure to check if the component is still mounted before changing any layer
- Add barely noticeable delays between each route-specific layer to avoid weird display issue on iOS
- Change the order in which camera, user location, geo layers and route layers are loaded
- Make sure to check if `layerController == null` before using it