### PR TITLE
Change type of GHInstruction-turnAngle variable to the type provided by GraphHopper (double)

### DIFF
--- a/lib/routing/messages/graphhopper.dart
+++ b/lib/routing/messages/graphhopper.dart
@@ -212,7 +212,7 @@ class GHInstruction {
 
   /// Only available for roundabout instructions (sign is 6). The radian of the route within
   /// the roundabout 0 < r < 2*PI for clockwise and -2*PI < r < 0 for counterclockwise turns.
-  final String? turnAngle;
+  final double? turnAngle;
 
   const GHInstruction({
     required this.text,


### PR DESCRIPTION
Before it was a string and thus, if GraphHopper returned a `turn_angle` for the route, it resulted in an Error when decoding the response (string /= double).

A test user got this error when trying to create a specific route with the profile `mtb_fastest` (osm-routing). For this route the profile `mtb_fastest` was the only one returning a `turn_angle`. 

Corresponding ticket: https://trello.com/c/Y9zYM5zj/415-teilweise-kann-die-route-nicht-erstellt-werden