### PR TITLE
Remove redundant progress from the statistics and add padding for compensation

### DIFF
--- a/lib/statistics/views/total.dart
+++ b/lib/statistics/views/total.dart
@@ -99,143 +99,131 @@ class TotalStatisticsViewState extends State<TotalStatisticsView> {
   }
 
   Widget renderCo2Stats() {
-    return Row(
-      children: [
-        Container(
-          alignment: Alignment.centerLeft,
-          padding: EdgeInsets.only(top: paddingStats, bottom: paddingStats),
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              BoldContent(
-                text: (statistics.totalSavedCO2Kg ?? 0) < 1
-                    ? "${((statistics.totalSavedCO2Kg ?? 0) * 1000).toStringAsFixed(1)} g"
-                    : "${(statistics.totalSavedCO2Kg)?.toStringAsFixed(1) ?? 0} kg",
-                context: context,
-              ),
-              const SizedBox(height: 4),
-              Small(text: "CO2", context: context),
-            ],
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 5),
+      child: Row(
+        children: [
+          Container(
+            alignment: Alignment.centerLeft,
+            padding: EdgeInsets.only(top: paddingStats, bottom: paddingStats),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Small(text: "CO2", context: context),
+              ],
+            ),
           ),
-        ),
-        const HSpace(),
-        Expanded(child: Container()),
-        Container(
-          alignment: Alignment.centerRight,
-          child: LevelView(
-            levels: const [
-              // Bronze levels
-              Level(value: 0, title: "Öko-Kämpfer", color: Medals.bronze),
-              Level(value: 1, title: "Grüner Riese", color: Medals.bronze),
-              // Silver levels
-              Level(value: 5, title: "Planetenschützer", color: Medals.silver),
-              Level(value: 10, title: "Nachhaltigkeits-Star", color: Medals.silver),
-              // Gold levels
-              Level(value: 25, title: "Öko-Held", color: Medals.gold),
-              Level(value: 50, title: "Umwelt-Retter", color: Medals.gold),
-              // PrioBike (Blue) levels
-              Level(value: 100, title: "Klima-Champion", color: Medals.priobike),
-            ],
-            value: (statistics.totalSavedCO2Kg ?? 0),
-            icon: Icons.co2_rounded,
-            unit: "kg",
+          const HSpace(),
+          Expanded(child: Container()),
+          Container(
+            alignment: Alignment.centerRight,
+            child: LevelView(
+              levels: const [
+                // Bronze levels
+                Level(value: 0, title: "Öko-Kämpfer", color: Medals.bronze),
+                Level(value: 1, title: "Grüner Riese", color: Medals.bronze),
+                // Silver levels
+                Level(value: 5, title: "Planetenschützer", color: Medals.silver),
+                Level(value: 10, title: "Nachhaltigkeits-Star", color: Medals.silver),
+                // Gold levels
+                Level(value: 25, title: "Öko-Held", color: Medals.gold),
+                Level(value: 50, title: "Umwelt-Retter", color: Medals.gold),
+                // PrioBike (Blue) levels
+                Level(value: 100, title: "Klima-Champion", color: Medals.priobike),
+              ],
+              value: (statistics.totalSavedCO2Kg ?? 0),
+              icon: Icons.co2_rounded,
+              unit: "kg",
+            ),
           ),
-        ),
-      ],
+        ],
+      ),
     );
   }
 
   Widget renderDistanceStats() {
-    return Row(
-      children: [
-        Container(
-          alignment: Alignment.centerLeft,
-          padding: EdgeInsets.only(top: paddingStats, bottom: paddingStats),
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              BoldContent(
-                text: (statistics.totalDistanceMeters ?? 0) >= 1000
-                    ? "${((statistics.totalDistanceMeters ?? 0) / 1000).toStringAsFixed(2)} km"
-                    : "${(statistics.totalDistanceMeters ?? 0).toStringAsFixed(0)} m",
-                context: context,
-              ),
-              const SizedBox(height: 4),
-              Small(text: "Distanz", context: context),
-            ],
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 5),
+      child: Row(
+        children: [
+          Container(
+            alignment: Alignment.centerLeft,
+            padding: EdgeInsets.only(top: paddingStats, bottom: paddingStats),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Small(text: "Distanz", context: context),
+              ],
+            ),
           ),
-        ),
-        const HSpace(),
-        Expanded(child: Container()),
-        Container(
-          alignment: Alignment.centerRight,
-          child: LevelView(
-            levels: const [
-              // Bronze levels
-              Level(value: 0, title: "Meilen-Mampfer", color: Medals.bronze),
-              Level(value: 50, title: "Zweirad-Wanderer", color: Medals.bronze),
-              // Silver levels
-              Level(value: 100, title: "Radfahr-Begleiter", color: Medals.silver),
-              Level(value: 150, title: "Fahrrad-Buddha", color: Medals.silver),
-              // Gold levels
-              Level(value: 250, title: "Velociped-Virtuose", color: Medals.gold),
-              Level(value: 500, title: "Sattel-Kenner", color: Medals.gold),
-              // PrioBike (Blue) levels
-              Level(value: 1000, title: "Radfahr-Champion", color: Medals.priobike),
-            ],
-            value: (statistics.totalDistanceMeters ?? 0) / 1000,
-            icon: Icons.directions_bike_rounded,
-            unit: "km",
+          const HSpace(),
+          Expanded(child: Container()),
+          Container(
+            alignment: Alignment.centerRight,
+            child: LevelView(
+              levels: const [
+                // Bronze levels
+                Level(value: 0, title: "Meilen-Mampfer", color: Medals.bronze),
+                Level(value: 50, title: "Zweirad-Wanderer", color: Medals.bronze),
+                // Silver levels
+                Level(value: 100, title: "Radfahr-Begleiter", color: Medals.silver),
+                Level(value: 150, title: "Fahrrad-Buddha", color: Medals.silver),
+                // Gold levels
+                Level(value: 250, title: "Velociped-Virtuose", color: Medals.gold),
+                Level(value: 500, title: "Sattel-Kenner", color: Medals.gold),
+                // PrioBike (Blue) levels
+                Level(value: 1000, title: "Radfahr-Champion", color: Medals.priobike),
+              ],
+              value: (statistics.totalDistanceMeters ?? 0) / 1000,
+              icon: Icons.directions_bike_rounded,
+              unit: "km",
+            ),
           ),
-        ),
-      ],
+        ],
+      ),
     );
   }
 
   Widget renderDurationStats() {
-    return Row(
-      children: [
-        Container(
-          alignment: Alignment.centerLeft,
-          padding: EdgeInsets.only(top: paddingStats, bottom: paddingStats),
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              BoldContent(
-                text: (statistics.totalDurationSeconds ?? 0.0) >= 3600
-                    ? "${Duration(seconds: (statistics.totalDurationSeconds ?? 0.0).toInt()).toString().split('.').first} Std."
-                    : "${((statistics.totalDurationSeconds ?? 0) / 60).toStringAsFixed(0)} Min.",
-                context: context,
-              ),
-              const SizedBox(height: 4),
-              Small(text: "Zeit", context: context),
-            ],
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 5),
+      child: Row(
+        children: [
+          Container(
+            alignment: Alignment.centerLeft,
+            padding: EdgeInsets.only(top: paddingStats, bottom: paddingStats),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Small(text: "Zeit", context: context),
+              ],
+            ),
           ),
-        ),
-        const HSpace(),
-        Expanded(child: Container()),
-        Container(
-          alignment: Alignment.centerRight,
-          child: LevelView(
-            levels: const [
-              // Bronze levels
-              Level(value: 0, title: "Radel-Rookie", color: Medals.bronze),
-              Level(value: 10, title: "Mittelstrecken-Fahrer", color: Medals.bronze),
-              // Silver levels
-              Level(value: 30, title: "Dauerläufer", color: Medals.silver),
-              Level(value: 180, title: "Bike-Boss", color: Medals.silver),
-              // Gold levels
-              Level(value: 600, title: "Pedal-Powerhouse", color: Medals.gold),
-              Level(value: 1200, title: "Tour de Force", color: Medals.gold),
-              // PrioBike (Blue) levels
-              Level(value: 3000, title: "Radrennen-Routinier", color: Medals.priobike),
-            ],
-            value: (statistics.totalDurationSeconds ?? 0.0) / 60,
-            icon: Icons.timer_outlined,
-            unit: "min",
+          const HSpace(),
+          Expanded(child: Container()),
+          Container(
+            alignment: Alignment.centerRight,
+            child: LevelView(
+              levels: const [
+                // Bronze levels
+                Level(value: 0, title: "Radel-Rookie", color: Medals.bronze),
+                Level(value: 10, title: "Mittelstrecken-Fahrer", color: Medals.bronze),
+                // Silver levels
+                Level(value: 30, title: "Dauerläufer", color: Medals.silver),
+                Level(value: 180, title: "Bike-Boss", color: Medals.silver),
+                // Gold levels
+                Level(value: 600, title: "Pedal-Powerhouse", color: Medals.gold),
+                Level(value: 1200, title: "Tour de Force", color: Medals.gold),
+                // PrioBike (Blue) levels
+                Level(value: 3000, title: "Radrennen-Routinier", color: Medals.priobike),
+              ],
+              value: (statistics.totalDurationSeconds ?? 0.0) / 60,
+              icon: Icons.timer_outlined,
+              unit: "min",
+            ),
           ),
-        ),
-      ],
+        ],
+      ),
     );
   }
 


### PR DESCRIPTION
On small displays and higher progress values the gamification levels were overflowing on the right. Removing the progress value from the left fixes this. This can be done because it is redundant since it's also shown in the gamification level right next to it. This breaks the chosen design because the height of the single statistic rows (CO2, distance and time) got set by the label ("CO2"/"Distanz"/"Zeit") together with the value above (e.g. "100g", "30km", "40min"). When the latter is gone now the rows are very close together. To keep the old distance between the rows a padding got added.

Corresponding ticket: https://trello.com/c/YQC0rqQY/425-overflow-bei-den-h%C3%B6heren-fortschrittsleveln-bei-kleineren-displays-handys