### PR TITLE
Change opacity of surface color in light/dark color schemes

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -110,7 +110,7 @@ class App extends StatelessWidget {
                 background: Color(0xFFFFFFFF),
                 primary: CI.blue,
                 secondary: CI.lightBlue,
-                surface: Color(0xF6F6F6FF),
+                surface: Color(0xFFF6F6FF),
                 brightness: Brightness.light,
               ),
               textTheme: const TextTheme(
@@ -165,7 +165,7 @@ class App extends StatelessWidget {
                 background: Color(0xFF232323),
                 primary: CI.blue,
                 secondary: CI.lightBlue,
-                surface: Color(0xF63B3B3B),
+                surface: Color(0xFF3B3B3B),
                 brightness: Brightness.dark,
               ),
               textTheme: const TextTheme(


### PR DESCRIPTION
Fixes the buggy transition to the settings view on iOS (before the home view was still visible for a few moments after the transition).

@PhilippMatthes Please look if the colors are still how you want them to be. I removed the transparency, because that seems to have caused the buggy transition. Therefore the colors changed a bit.