### PR TITLE
made routing view available on click in edit view

### DIFF
--- a/lib/home/views/shortcuts/edit.dart
+++ b/lib/home/views/shortcuts/edit.dart
@@ -112,8 +112,10 @@ class ShortcutsEditViewState extends State<ShortcutsEditView> {
                             onPressed: () {
                               routing.selectWaypoints(entry.value.waypoints);
 
-                              Navigator.of(context).push(MaterialPageRoute(builder: (_) => const RoutingViewWrapper()))
-                                  .then((_) {
+                              Navigator.of(context)
+                                  .push(MaterialPageRoute(builder: (_) => const RoutingViewWrapper()))
+                                  .then(
+                                (_) {
                                   routing.reset();
                                   discomforts.reset();
                                   predictionSGStatus.reset();


### PR DESCRIPTION
In the edit view of the routes, you can now start a route by clicking on it.

However, I am unsure whether this might create false expectations in the user. When I open an edit view and click on a route, I assume that I can now edit it (change start/destination, order, etc.). I mean that is theoretically possible, only after these changes the user has to drive the route once to save the changes. But maybe it's just me :D 