### PR TITLE
Use textureView instead of surfaceView on Android for Mapbox

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,23 @@ Since Android 12 implements its own splash screen, a solution must be found for 
 
 On push to `dev` or `beta`, a build workflow will be triggered to distribute our app.
 
+## Clean up Android logs
+
+Since we use the textureView for our Mapbox Maps, the log gets spammed with the following message:
+```
+updateAcquireFence: Did not find frame.
+```
+According to [this](https://github.com/flutter/flutter/issues/104268#issuecomment-1134964433), this is meaningless for us. Therefore we can use filters in our IDE to exclude this message from the log (ensuring a clean log).
+
+For Android Studio include the following filter when using Logcat:
+```
+package=:de.tudresden.priobike -message:"updateAcquireFence: Did not find frame."
+```
+For Visual Studio Code it is not that important because it groups the messages already such that they are not that annoying. To exclude those use the following filter:
+```
+!updateAcquireFence: Did not find frame.
+```
+
 ## Documentation for Flutter
 
 For help getting started with Flutter, view the

--- a/lib/common/map/view.dart
+++ b/lib/common/map/view.dart
@@ -109,12 +109,23 @@ class AppMapState extends State<AppMap> {
       onStyleLoadedListener: widget.onStyleLoaded,
       onTapListener: widget.onMapTap,
       onCameraChangeListener: widget.onCameraChanged,
-      // Setting the following line (textureView) to true results in a spam of the message (only effects Android):
-      // "updateAcquireFence: Did not find frame."
-      // Setting the line (textureView) to false results in a spam of the message (only effects Android):
-      // "[SurfaceTexture-0-26276-3](id:66a40000000b,api:1,p:627,c:26276) dequeueBuffer: BufferQueue has been abandoned"
-      // Other effects were not yet observed.
-      // textureView: false,
+      // ONLY AFFECTS ANDROID
+      // If set to false, surfaceView is used instead.
+      // "Although SurfaceView is very efficient, it might not fit all use cases as it creates a separate window and
+      // cannot be moved, transformed, or animated. For these situations where you need more flexibility,
+      // it’s usually best to use a TextureView. This is less performant than SurfaceView, but it behaves as a standard
+      // View and can be manipulated as such." https://blog.mapbox.com/asynchronous-rendering-on-android-831722ac1837
+      // We use this to mitigate blank maps (observed when using the surfaceView and using the app excessively
+      // (e.g. starting a lot of rides/opening and closing map views without closing the app in between))
+      textureView: true,
+      mapOptions: mapbox.MapOptions(
+        // Setting this to UNIQUE allows Mapbox to perform optimizations (only possible if the GL context is not
+        // shared (not used by other frameworks/code except Mapbox))
+        contextMode: mapbox.ContextMode.UNIQUE,
+        // Has to be set if we set the MapOptions (thus, if we remove the contextMode we can also remove the
+        // pixelRatio)
+        pixelRatio: MediaQuery.of(context).devicePixelRatio,
+      ),
       cameraOptions: mapbox.CameraOptions(
         center: turf.Point(
             coordinates: turf.Position(


### PR DESCRIPTION
It's hard to test this problem because of its difficult-to-predict nature. Therefore it could be that this fix is not a final fix, but during my tests I was not able to reproduce the problem using `textureView` in comparison to `surfaceView`. I was not able to recognize performance issues that could result from using the `textureView`.

In addition to the switch from `surfaceView` to `textureView` I also changed the `contextMode` of Mapbox to `UNIQUE`. This change is based on the fact that Mapbox is currently the only plugin/code using OpenGL in our app which - according to Mapbox - enables some "optimizations" on Mapbox-side. 

Corresponding ticket: https://trello.com/c/WAQ1fsqy