### PR TITLE
Change weather view such that forecast is only shown on large screens

### DIFF
--- a/lib/weather/view.dart
+++ b/lib/weather/view.dart
@@ -142,60 +142,63 @@ class WeatherViewState extends State<WeatherView> {
     }
     summary = "${summary!} bei ${temp.toStringAsFixed(1)}°C.";
 
-    if (MediaQuery.of(context).size.height > 550) {
-      // Check if the icon changes in the forecast.
-      for (final forecast in weather.forecast ?? <WeatherForecast>[]) {
-        if (forecast.icon != weather.current?.icon) {
-          // Convert the timestamp to a clock time.
-          final clock = "${forecast.timestamp.hour.toString()}:${forecast.timestamp.minute.toString().padLeft(2, '0')}";
-          final isTomorrow = forecast.timestamp.day != DateTime.now().day;
-          summary = "${summary!}${isTomorrow ? ' Morgen' : ' Heute'} ab $clock Uhr wird es";
-          switch (forecast.icon) {
-            case "clear-day":
-              summary = "${summary!} sonnig.";
-              break;
-            case "clear-night":
-              summary = "${summary!} klar.";
-              break;
-            case "partly-cloudy-day":
-              summary = "${summary!} teilweise bewölkt.";
-              break;
-            case "partly-cloudy-night":
-              summary = "${summary!} teilweise bewölkt.";
-              break;
-            case "cloudy":
-              summary = "${summary!} bewölkt.";
-              break;
-            case "fog":
-              summary = "${summary!} neblig.";
-              break;
-            case "wind":
-              summary = "${summary!} windig.";
-              warning = true;
-              break;
-            case "rain":
-              summary = "${summary!} regnerisch.";
-              warning = true;
-              break;
-            case "sleet":
-              summary = "${summary!} schneien.";
-              warning = true;
-              break;
-            case "snow":
-              summary = "${summary!} schneien.";
-              warning = true;
-              break;
-            case "hail":
-              summary = "${summary!} hageln.";
-              warning = true;
-              break;
-            case "thunderstorm":
-              summary = "${summary!} gewittern.";
-              warning = true;
-              break;
-          }
-          break;
+    // Don't add the forecast to the summary if the display height is to small (resulting in an overflow).
+    if (MediaQuery.of(context).size.height < 550) {
+      return;
+    }
+
+    // Check if the icon changes in the forecast.
+    for (final forecast in weather.forecast ?? <WeatherForecast>[]) {
+      if (forecast.icon != weather.current?.icon) {
+        // Convert the timestamp to a clock time.
+        final clock = "${forecast.timestamp.hour.toString()}:${forecast.timestamp.minute.toString().padLeft(2, '0')}";
+        final isTomorrow = forecast.timestamp.day != DateTime.now().day;
+        summary = "${summary!}${isTomorrow ? ' Morgen' : ' Heute'} ab $clock Uhr wird es";
+        switch (forecast.icon) {
+          case "clear-day":
+            summary = "${summary!} sonnig.";
+            break;
+          case "clear-night":
+            summary = "${summary!} klar.";
+            break;
+          case "partly-cloudy-day":
+            summary = "${summary!} teilweise bewölkt.";
+            break;
+          case "partly-cloudy-night":
+            summary = "${summary!} teilweise bewölkt.";
+            break;
+          case "cloudy":
+            summary = "${summary!} bewölkt.";
+            break;
+          case "fog":
+            summary = "${summary!} neblig.";
+            break;
+          case "wind":
+            summary = "${summary!} windig.";
+            warning = true;
+            break;
+          case "rain":
+            summary = "${summary!} regnerisch.";
+            warning = true;
+            break;
+          case "sleet":
+            summary = "${summary!} schneien.";
+            warning = true;
+            break;
+          case "snow":
+            summary = "${summary!} schneien.";
+            warning = true;
+            break;
+          case "hail":
+            summary = "${summary!} hageln.";
+            warning = true;
+            break;
+          case "thunderstorm":
+            summary = "${summary!} gewittern.";
+            warning = true;
+            break;
         }
+        break;
       }
     }
   }


### PR DESCRIPTION
Testetd it on the following devices:
- Nexus S (overflow -> forecast not shown)
- Nexus 4 (no overflow -> forecast shown)
- Galaxy S10e (no overflow -> forecast shown)
- iPhone XR (no overflow -> forecast shown)
- iPhone 14 Pro (no overflow -> forecast shown)

The threshold for the height is not carved in stone yet but on the test devices it worked well.
I think it would be good if you could also test it on your small iPhone and adjust the threshold if needed. @PhilippMatthes 

The height for the Nexus S is 533 and for the Nexus 4 592. For the other phones it is even higher.

Corresponding ticket: https://trello.com/c/NifOkbMp