### PR TITLE
Fix initial zoom

### DIFF
--- a/lib/routing/views_beta/map.dart
+++ b/lib/routing/views_beta/map.dart
@@ -203,8 +203,8 @@ class RoutingMapViewState extends State<RoutingMapView> with TickerProviderState
         bottom: 0.175 * frame.size.height * frame.devicePixelRatio,
         right: 0);
     if (Platform.isIOS) {
-      insets.top = insets.top * 0.4; // FIXME @daniel 2 * 0.4 for ios here?
-      insets.bottom = insets.bottom * 0.2; // FIXME @daniel 2 * 0.2 for ios here?
+      insets.top = insets.top * 0.4;
+      insets.bottom = insets.bottom * 0.2;
     }
     final cameraOptionsForBounds = await mapController?.cameraForCoordinateBounds(
       routing.selectedRoute!.paddedBounds,


### PR DESCRIPTION
@adeveloper-wq you had the * 0.4 and * 0.2 in the android insets. I think you have to set the values for IOs to 0.8 and 0.4. Could you please check this with the IOs device?