### PR TITLE
Hotfix for the used matcher parameter of the sg-selector url

### DIFF
--- a/lib/routing/services/routing.dart
+++ b/lib/routing/services/routing.dart
@@ -242,7 +242,7 @@ class Routing with ChangeNotifier {
         usedRoutingParameter = "osm";
       }
       final sgSelectorUrl =
-          "https://$baseUrl/sg-selector-backend/routing/select?matcher${settings.sgSelector.servicePathParameter}&routing=$usedRoutingParameter";
+          "https://$baseUrl/sg-selector-backend/routing/select?matcher=${settings.sgSelector.servicePathParameter}&routing=$usedRoutingParameter";
       final sgSelectorEndpoint = Uri.parse(sgSelectorUrl);
       log.i("Loading SG-Selector response from $sgSelectorUrl");
 


### PR DESCRIPTION
- Added '=' to sg-selector url