### PR TITLE
Remove delay on start up of ride view used as a workaround previously

### DIFF
--- a/lib/ride/views/main.dart
+++ b/lib/ride/views/main.dart
@@ -1,8 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/scheduler.dart';
-import 'package:priobike/common/layout/spacing.dart';
-import 'package:priobike/common/layout/text.dart';
-import 'package:priobike/common/layout/tiles.dart';
 import 'package:priobike/common/lock.dart';
 import 'package:priobike/dangers/services/dangers.dart';
 import 'package:priobike/dangers/views/button.dart';
@@ -40,9 +37,6 @@ class RideViewState extends State<RideView> {
   /// A lock that avoids rapid rerouting.
   final lock = Lock(milliseconds: 10000);
 
-  /// Indicating whether the widgets can be loaded or the loading screen should be shown.
-  bool ready = false;
-
   /// Called when a listener callback of a ChangeNotifier is fired.
   void update() => setState(() {});
 
@@ -52,14 +46,6 @@ class RideViewState extends State<RideView> {
 
     settings = getIt<Settings>();
     settings.addListener(update);
-
-    // Wait a moment for a clean disposal of the map in the routing view.
-    // Without that at the moment it won't dispose correctly causing some weird bugs.
-    Future.delayed(const Duration(milliseconds: 2000), () {
-      setState(() {
-        ready = true;
-      });
-    });
 
     SchedulerBinding.instance.addPostFrameCallback(
       (_) async {
@@ -127,33 +113,6 @@ class RideViewState extends State<RideView> {
     super.dispose();
   }
 
-  /// Render a loading indicator.
-  Widget renderLoadingIndicator() {
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        Expanded(
-          child: Tile(
-            fill: Theme.of(context).colorScheme.surface,
-            content: Center(
-              child: SizedBox(
-                height: 86,
-                width: 256,
-                child: Column(
-                  children: [
-                    const CircularProgressIndicator(),
-                    const VSpace(),
-                    BoldContent(text: "Lade...", maxLines: 1, context: context),
-                  ],
-                ),
-              ),
-            ),
-          ),
-        ),
-      ],
-    );
-  }
-
   @override
   Widget build(BuildContext context) {
     // Keep the device active during navigation.
@@ -162,21 +121,19 @@ class RideViewState extends State<RideView> {
     return WillPopScope(
       onWillPop: () async => false,
       child: Scaffold(
-        body: !ready
-            ? renderLoadingIndicator()
-            : ScreenTrackingView(
-                child: Stack(
-                  alignment: Alignment.bottomCenter,
-                  clipBehavior: Clip.none,
-                  children: const [
-                    RideMapView(),
-                    RideSpeedometerView(),
-                    DatastreamView(),
-                    RideSGButton(),
-                    DangerButton(),
-                  ],
-                ),
-              ),
+        body: ScreenTrackingView(
+          child: Stack(
+            alignment: Alignment.bottomCenter,
+            clipBehavior: Clip.none,
+            children: const [
+              RideMapView(),
+              RideSpeedometerView(),
+              DatastreamView(),
+              RideSGButton(),
+              DangerButton(),
+            ],
+          ),
+        ),
       ),
     );
   }


### PR DESCRIPTION
Tested on the devices iPhone XR and Galaxy S10e as well as Nexus S and Nexus 4 emulators. Seems that the delay is not necessary any longer (no errors in the log as well as no problems when going from routing to ride view).

Ticket: https://trello.com/c/LhG0e8bb/509-testen-ob-der-loadingscreen-zwischen-routingview-und-rideview-noch-notwendig-ist