### PR TITLE
Route zoom padding

### DIFF
--- a/lib/routing/views/map.dart
+++ b/lib/routing/views/map.dart
@@ -236,13 +236,23 @@ class RoutingMapViewState extends State<RoutingMapView> with TickerProviderState
   fitCameraToRouteBounds() async {
     if (mapController == null || !mounted) return;
     if (routing.selectedRoute == null) return;
+    final frame = MediaQuery.of(context);
     // The delay is necessary, otherwise sometimes the camera won't move.
     await Future.delayed(const Duration(milliseconds: 500));
     final currentCameraOptions = await mapController?.getCameraState();
     if (currentCameraOptions == null) return;
+
+    MbxEdgeInsets insetsAndroid = MbxEdgeInsets(
+        // (AppBackButton height + top padding) * devicePixelRatio
+        top: (64 + 16 + frame.padding.top) * frame.devicePixelRatio,
+        left: 0,
+        // (BottomSheet height + bottom padding) * devicePixelRatio
+        bottom: (116 + frame.padding.bottom) * frame.devicePixelRatio,
+        right: 0);
+
     final cameraOptionsForBounds = await mapController?.cameraForCoordinateBounds(
       routing.selectedRoute!.paddedBounds,
-      currentCameraOptions.padding,
+      Platform.isIOS ? currentCameraOptions.padding : insetsAndroid,
       currentCameraOptions.bearing,
       currentCameraOptions.pitch,
     );


### PR DESCRIPTION
Add Padding (BottomSheet & Discomfort) to the camera fly when a route is selected. 

Changes:

Before
<img src="https://user-images.githubusercontent.com/33689888/233942611-632a4903-7188-413c-abe3-25c112825274.png"  alt="image" width="200px" height="400" >

After
<img src="https://user-images.githubusercontent.com/33689888/233945341-96db7758-be9b-4284-a1b0-9e97267b623a.png"  alt="image" width="200px" height="400" >

@adeveloper-wq please check the changes on IOs. We probably need to add the 0.2 on the padding like in the beta. 
`if (Platform.isIOS) {
      insets.top = insets.top * 0.4;
      insets.bottom = insets.bottom * 0.2;
    }`