### PR TITLE
added attributions of geo data

### DIFF
--- a/assets/text/thanks.txt
+++ b/assets/text/thanks.txt
@@ -72,6 +72,10 @@ Link zum Datensatz: https://download.geofabrik.de/europe/germany/hamburg.html
 Open Data Commons Open Database License (ODbL)
 Link zur Lizenz: https://opendatacommons.org/licenses/odbl/summary/
 
-
+API-Nutzung für das Bereitstellen von aktuellen Wettervorhersagen.
+Wetterdaten bereitgestellt durch den Deutschen Wetter Dienst.
+Datenaufbereitung durch 'BrightSky'.
+Link zur API: https://brightsky.dev/
+Link zum DWD: https://dwd.de
 
 Realisation der App: Technische Universität Dresden.


### PR DESCRIPTION
Added attribution for (all?) of the used external data sources. I cannot guarantee that my list is complete. 
However, for two of the sources I found I am not sure how to cite them correctly. 

One is the <a href="https://docs.mapbox.com/data/tilesets/reference/mapbox-traffic-v1/">`Vector Tile dataset`</a> of the traffic. In the  'Attribution' section of this page, you find that a MapBox logo must be visible on the map. Since this has already been done, I don't know whether it should/must be mentioned again.

The other source I am unsure about is the use of the <a href="https://github.com/jdemaeyer/brightsky/">weather from `brightsky`</a>. In the repository, an MIT licence is provided, but that shouldn't really matter, since we don't use the software directly, but only the data provided. The data comes from the DWD. They have the following copyright details: <a href="https://www.dwd.de/EN/service/copyright/copyright_artikel.html.">Copyright</a>. Since I am not a lawyer, I have no idea how to quote this correctly. I have sent an email to the developer of the API, but I am still waiting for a reply.
