### PR TITLE
Fix map glitches on android after search screen closes

### DIFF
--- a/lib/routing/views/search.dart
+++ b/lib/routing/views/search.dart
@@ -336,6 +336,7 @@ class RouteSearchState extends State<RouteSearch> {
               children: [
                 AppBackButton(
                   onPressed: () async {
+                    // FIXME we should pay attention to release notes if this Flutter bug might be fixed in the future.
                     // Prevents the keyboard to be focused on pop screen. This can cause ugly map effects on Android.
                     if (Platform.isAndroid && searchTextFieldFocusNode.hasFocus) {
                       searchTextFieldFocusNode.unfocus();


### PR DESCRIPTION
The keyboard took too long to unfocus. Therefore the Stack that holds the map and the bottomsheet was displayed at 50% height. Now before leaving the search screen, the focus of the keyboard gets checked and unfocused if needed. Since there is no return when the keyboard is done unfocusing, a delay is used to make sure the screen pops after the keyboard got unfocused.