### PR TITLE
Fix route height chart displayed without route

### DIFF
--- a/lib/routing/views/details/height.dart
+++ b/lib/routing/views/details/height.dart
@@ -428,6 +428,7 @@ class RouteHeightChartState extends State<RouteHeightChart> {
   @override
   Widget build(BuildContext context) {
     if (lineElements.isEmpty || maxDistance == 0.0) return Container();
+    if (routing.selectedRoute == null) return Container();
 
     return Container(
       decoration: BoxDecoration(


### PR DESCRIPTION
Adds check if a route is selected before displaying the route height chart.