### PR TITLE
Survey launch in external application

### DIFF
--- a/lib/home/views/survey.dart
+++ b/lib/home/views/survey.dart
@@ -31,7 +31,7 @@ class SurveyViewState extends State<SurveyView> {
   }
 
   Future<void> _launchSurvey() async {
-    if (!await launchUrl(_url)) {
+    if (!await launchUrl(_url, mode: LaunchMode.externalApplication)) {
       throw Exception('Could not launch $_url');
     }
   }


### PR DESCRIPTION
In the current version, there was no possibility to look at the app again during the survey. However, this is a great advantage for some questions (app version, for example). Therefore, the survey is no longer opened in the internal browser. The url is now passed to the OS, which will handle the launch in another application.