### PR TITLE
Color of "Jetzt" in status map now depends on background color

### DIFF
--- a/lib/status/views/status.dart
+++ b/lib/status/views/status.dart
@@ -96,9 +96,9 @@ class StatusViewState extends State<StatusView> {
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             BoldSmall(
-                text: "Jetzt",
-                color: isProblem ? Colors.white : Theme.of(context).colorScheme.onBackground,
-                context: context
+              text: "Jetzt",
+              color: isProblem ? Colors.white : Theme.of(context).colorScheme.onBackground,
+              context: context,
             ),
             const SmallVSpace(),
             Row(


### PR DESCRIPTION
Ticket: https://trello.com/c/OSBc2Xvk

If there is a problem (red background) it will now always be white.
If not (background: light mode -> white, dark mode -> black) it uses the colorScheme.onBackground of the current theme.

