### PR TITLE
Fix text not aligned correctly after status text update

### DIFF
--- a/lib/home/views/main.dart
+++ b/lib/home/views/main.dart
@@ -265,8 +265,8 @@ class HomeViewState extends State<HomeView> with WidgetsBindingObserver, RouteAw
                       ),
                     ),
                   const VSpace(),
-                  const BlendIn(
-                    child: StatusTabsView(),
+                  BlendIn(
+                    child: StatusTabsView(triggerRebuild: () => setState(() {})),
                   ),
                   const VSpace(),
                   BlendIn(

--- a/lib/status/views/status.dart
+++ b/lib/status/views/status.dart
@@ -8,7 +8,9 @@ import 'package:priobike/status/services/summary.dart';
 import 'package:priobike/status/views/map.dart';
 
 class StatusView extends StatefulWidget {
-  const StatusView({Key? key}) : super(key: key);
+  final Function triggerRebuild;
+
+  const StatusView({Key? key, required this.triggerRebuild}) : super(key: key);
 
   @override
   StatusViewState createState() => StatusViewState();
@@ -32,6 +34,7 @@ class StatusViewState extends State<StatusView> {
     text = loadText();
     goodPct = loadGood();
     setState(() {});
+    widget.triggerRebuild;
   }
 
   @override

--- a/lib/status/views/status_tabs.dart
+++ b/lib/status/views/status_tabs.dart
@@ -150,7 +150,9 @@ class _SizeReportingWidgetState extends State<SizeReportingWidget> {
 }
 
 class StatusTabsView extends StatefulWidget {
-  const StatusTabsView({Key? key}) : super(key: key);
+  final Function triggerRebuild;
+
+  const StatusTabsView({Key? key, required this.triggerRebuild}) : super(key: key);
 
   @override
   StatusTabsViewState createState() => StatusTabsViewState();
@@ -180,11 +182,11 @@ class StatusTabsViewState extends State<StatusTabsView> {
   Widget build(BuildContext context) {
     return SizedBox(
       width: MediaQuery.of(context).size.width,
-      child: const ExpandablePageView(
+      child: ExpandablePageView(
         children: [
-          StatusView(),
-          StatusHistoryView(time: StatusHistoryTime.day),
-          StatusHistoryView(time: StatusHistoryTime.week),
+          StatusView(triggerRebuild: widget.triggerRebuild),
+          const StatusHistoryView(time: StatusHistoryTime.day),
+          const StatusHistoryView(time: StatusHistoryTime.week),
         ],
       ),
     );


### PR DESCRIPTION
Fixes the bug where the "Deine Strecken ..." component is above the statusbar. 

This can happen when the status updates. Then the `home/main` is not retriggerd to build the view. 

Tested this bug by manually changing the text after 2 seconds and trigger the rebuild after 2 seconds (see video).
The rebuild will be triggerd immediately in the fix.

https://github.com/priobike/priobike-flutter-app/assets/33689888/f8b5b67a-01bb-43c7-9327-01989910556c

