### PR TITLE
Deletion bug last rides

### DIFF
--- a/lib/tracking/views/all_track_history.dart
+++ b/lib/tracking/views/all_track_history.dart
@@ -177,6 +177,7 @@ class AllTracksHistoryViewState extends State<AllTracksHistoryView> {
                                 curve: Curves.easeInOutCubic,
                                 delay: Duration(milliseconds: 200 * track.key),
                                 child: TrackHistoryItemView(
+                                  key: UniqueKey(),
                                   track: track.value,
                                   width: shortcutWidth,
                                   height: shortcutHeight,

--- a/lib/tracking/views/track_history.dart
+++ b/lib/tracking/views/track_history.dart
@@ -140,6 +140,7 @@ class TrackHistoryViewState extends State<TrackHistoryView> {
     views += newestTracks
         .map(
           (track) => TrackHistoryItemView(
+            key: UniqueKey(),
             track: track,
             width: shortcutWidth,
             height: shortcutHeight,

--- a/lib/tracking/views/track_history_item.dart
+++ b/lib/tracking/views/track_history_item.dart
@@ -240,6 +240,7 @@ class TrackHistoryItemViewState extends State<TrackHistoryItemView> {
                     height: widget.width * 0.3,
                     width: widget.width * 0.3,
                     child: RoutePictogram(
+                      key: UniqueKey(),
                       route: routeNodes,
                       startImage: widget.startImage,
                       destinationImage: widget.destinationImage,
@@ -250,7 +251,6 @@ class TrackHistoryItemViewState extends State<TrackHistoryItemView> {
                 right: 0,
                 top: 0,
                 child: IconButton(
-                  key: const ValueKey("delete"),
                   onPressed: () => showDeleteDialog(),
                   icon: Icon(
                     Icons.delete_rounded,


### PR DESCRIPTION
Problem described by Philipp: "Ich habe gerade versehentlich ein paar Tracks gelöscht, weil die Buttons zum Löschen über den Kacheln zwar ausgeblendet werden aber immer noch klickbar sind"

Changelog for TrackHistoryItems:
- Whole widget is now clickable and shows details
- Add Icon to delete
- Remove Menu
- Add unique keys to widgets to fix deletion bug