### PR TITLE
Fix layout shift at status history

### DIFF
--- a/lib/status/views/status_history.dart
+++ b/lib/status/views/status_history.dart
@@ -69,7 +69,7 @@ class StatusHistoryViewState extends State<StatusHistoryView> {
         content: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           mainAxisSize: MainAxisSize.max,
-          mainAxisAlignment: MainAxisAlignment.start,
+          mainAxisAlignment: MainAxisAlignment.center,
           children: [
             BoldContent(
                 text: "Datenverfügbarkeit - ${widget.time.name()}",


### PR DESCRIPTION
Width on the statusbar items stay the same now while loading. Also added a circularProgressAnimation when loading data. Decided to still hide  the statusHistoryChart when loading since this can cause bugs. The painter needs to be reinitialized when for example the color mode got switched.