### PR TITLE
Fix Overflow of FeedbackView on Android

### DIFF
--- a/lib/feedback/views/main.dart
+++ b/lib/feedback/views/main.dart
@@ -158,89 +158,91 @@ class FeedbackViewState extends State<FeedbackView> {
 
     const bottomSheetHeight = 228.0;
 
-    return Scaffold(
-      bottomSheet: Container(
-        width: MediaQuery.of(context).size.width,
-        height: bottomSheetHeight,
-        color: Theme.of(context).colorScheme.primary,
-        child: Column(
-          children: [
-            const VSpace(),
-            const Padding(
-              padding: EdgeInsets.symmetric(horizontal: 32),
-              child: StarRatingView(text: "Dein Feedback zur App"),
-            ),
-            BigButton(
-              iconColor: Colors.white,
-              icon: Icons.check,
-              fillColor: Theme.of(context).colorScheme.background.withOpacity(0.25),
-              label: "Fertig",
-              onPressed: () => submit(),
-              boxConstraints: BoxConstraints(minWidth: MediaQuery.of(context).size.width - 24),
-            ),
-            BigButton(
-              iconColor: Colors.white,
-              icon: Icons.save_rounded,
-              fillColor: Theme.of(context).colorScheme.background.withOpacity(0.25),
-              label: "Strecke speichern",
-              onPressed: () => showSaveShortcutSheet(context),
-              boxConstraints: BoxConstraints(minWidth: MediaQuery.of(context).size.width - 24),
-            ),
-            const VSpace(),
-          ],
-        ),
-      ),
-      backgroundColor: Theme.of(context).colorScheme.surface,
-      body: SizedBox(
-        height: MediaQuery.of(context).size.height - bottomSheetHeight,
-        child: SingleChildScrollView(
-          key: const ValueKey("feedback_scroll_view"),
+    return SafeArea(
+      child: Scaffold(
+        bottomSheet: Container(
+          width: MediaQuery.of(context).size.width,
+          height: bottomSheetHeight,
+          color: Theme.of(context).colorScheme.primary,
           child: Column(
             children: [
-              Container(
-                padding: EdgeInsets.fromLTRB(24, MediaQuery.of(context).padding.top + 48, 24, 0),
-                child: () {
-                  if (start == "" || end == "") {
-                    return BoldContent(
-                      text: "Fahrt",
-                      context: context,
-                      textAlign: TextAlign.center,
-                    );
-                  } else {
-                    return Wrap(
-                      alignment: WrapAlignment.center,
-                      runAlignment: WrapAlignment.center,
-                      direction: Axis.horizontal,
-                      runSpacing: 8,
-                      children: [
-                        Content(
-                          text: "Von ",
-                          context: context,
-                        ),
-                        Content(
-                          text: start,
-                          context: context,
-                        ),
-                        Content(
-                          text: " nach ",
-                          context: context,
-                        ),
-                        Content(
-                          text: end,
-                          context: context,
-                        )
-                      ],
-                    );
-                  }
-                }(),
+              const VSpace(),
+              const Padding(
+                padding: EdgeInsets.symmetric(horizontal: 32),
+                child: StarRatingView(text: "Dein Feedback zur App"),
               ),
-              if (startImage != null && destinationImage != null)
-                TrackDetailsView(
-                  track: tracking.previousTracks!.last,
-                  startImage: startImage!,
-                  destinationImage: destinationImage!,
-                ),
+              BigButton(
+                iconColor: Colors.white,
+                icon: Icons.check,
+                fillColor: Theme.of(context).colorScheme.background.withOpacity(0.25),
+                label: "Fertig",
+                onPressed: () => submit(),
+                boxConstraints: BoxConstraints(minWidth: MediaQuery.of(context).size.width - 24),
+              ),
+              BigButton(
+                iconColor: Colors.white,
+                icon: Icons.save_rounded,
+                fillColor: Theme.of(context).colorScheme.background.withOpacity(0.25),
+                label: "Strecke speichern",
+                onPressed: () => showSaveShortcutSheet(context),
+                boxConstraints: BoxConstraints(minWidth: MediaQuery.of(context).size.width - 24),
+              ),
+              const VSpace(),
             ],
+          ),
+        ),
+        backgroundColor: Theme.of(context).colorScheme.surface,
+        body: SizedBox(
+          height: MediaQuery.of(context).size.height - bottomSheetHeight,
+          child: SingleChildScrollView(
+            key: const ValueKey("feedback_scroll_view"),
+            child: Column(
+              children: [
+                Container(
+                  padding: EdgeInsets.fromLTRB(24, MediaQuery.of(context).padding.top + 24, 24, 0),
+                  child: () {
+                    if (start == "" || end == "") {
+                      return BoldContent(
+                        text: "Fahrt",
+                        context: context,
+                        textAlign: TextAlign.center,
+                      );
+                    } else {
+                      return Wrap(
+                        alignment: WrapAlignment.center,
+                        runAlignment: WrapAlignment.center,
+                        direction: Axis.horizontal,
+                        runSpacing: 8,
+                        children: [
+                          Content(
+                            text: "Von ",
+                            context: context,
+                          ),
+                          Content(
+                            text: start,
+                            context: context,
+                          ),
+                          Content(
+                            text: " nach ",
+                            context: context,
+                          ),
+                          Content(
+                            text: end,
+                            context: context,
+                          )
+                        ],
+                      );
+                    }
+                  }(),
+                ),
+                if (startImage != null && destinationImage != null)
+                  TrackDetailsView(
+                    track: tracking.previousTracks!.last,
+                    startImage: startImage!,
+                    destinationImage: destinationImage!,
+                  ),
+              ],
+            ),
           ),
         ),
       ),


### PR DESCRIPTION
I've found a bug, where the feedback view would get too big when one opens the notifications on Android. This would cause the Android-Navigation-Buttons to been shown at the bottom (even though we tried to hide them), which would distort the view.

My suggestion would be to wrap everything in a SafeArea-Widget.

But then there is still the problem that the back-button is show but currently nothing happens when the user uses it. I'm not sure if that is what we want, but I left it this way for now.  

By the way, it looks like I've changed a lot but I just wrapped everything in a SafeArea and readjusted the paddings.

Before:
<img width="170" alt="image" src="https://github.com/priobike/priobike-flutter-app/assets/89537082/2802f61b-2d15-42e1-9fe1-d55767f9fe8f">

After:
<img width="170" alt="image" src="https://github.com/priobike/priobike-flutter-app/assets/89537082/7f8a8c87-8976-4203-970d-5598ddfedb924">