### PR TITLE
Add loading animation for track details

### DIFF
--- a/lib/tracking/views/track_history_item.dart
+++ b/lib/tracking/views/track_history_item.dart
@@ -17,7 +17,7 @@ import 'package:priobike/main.dart';
 import 'package:priobike/tracking/models/track.dart';
 import 'package:priobike/tracking/services/tracking.dart';
 import 'package:priobike/tracking/views/pictogram.dart';
-import 'package:priobike/tracking/views/ride_details.dart';
+import 'package:priobike/tracking/views/track_stats.dart';
 
 mixin TrackHistoryItem {
   /// The distance model.
@@ -346,16 +346,16 @@ class TrackHistoryItemDetailViewState extends State<TrackHistoryItemDetailView> 
           final savedCo2inG =
               distanceMeters == null && durationSeconds == null ? 0 : (distanceMeters! / 1000) * co2PerKm * 1000;
 
-          final Widget rideDetails;
+          final Widget trackStats;
           if (distanceMeters != null && durationSeconds != null && formattedTime != null) {
-            rideDetails = RideDetails(
+            trackStats = TrackStats(
               formattedTime: formattedTime,
               distanceMeters: distanceMeters,
               averageSpeedKmH: averageSpeedKmH,
               savedCo2inG: savedCo2inG,
             );
           } else {
-            rideDetails = const RideDetails();
+            trackStats = const TrackStats();
           }
 
           Widget content = Tile(
@@ -419,7 +419,7 @@ class TrackHistoryItemDetailViewState extends State<TrackHistoryItemDetailView> 
                               child: content),
                           Padding(
                             padding: const EdgeInsets.only(bottom: 24),
-                            child: rideDetails,
+                            child: trackStats,
                           )
                         ],
                       ),

--- a/lib/tracking/views/track_stats.dart
+++ b/lib/tracking/views/track_stats.dart
@@ -1,13 +1,13 @@
 import 'package:flutter/material.dart';
 
 /// A pictogram of a track.
-class RideDetails extends StatelessWidget {
+class TrackStats extends StatelessWidget {
   final String? formattedTime;
   final double? distanceMeters;
   final num? averageSpeedKmH;
   final num? savedCo2inG;
 
-  const RideDetails({
+  const TrackStats({
     Key? key,
     this.formattedTime,
     this.distanceMeters,


### PR DESCRIPTION
Außerdem habe ich zu internen Features einen Button hinzugefügt mit dem man einen Mock-Track generieren kann.

[Trello](https://trello.com/c/azFsu0Jp)

![loading_anim](https://github.com/priobike/priobike-flutter-app/assets/34790464/c3f9321d-d38c-4ef5-b7ca-fa76950f8cfd)
