### PR TITLE
Integrate Shortcut-Location into Gamification

### DIFF
--- a/lib/gamification/statistics/views/card/route_stats.dart
+++ b/lib/gamification/statistics/views/card/route_stats.dart
@@ -8,7 +8,6 @@ import 'package:priobike/gamification/goals/services/goals_service.dart';
 import 'package:priobike/gamification/statistics/models/ride_stats.dart';
 import 'package:priobike/gamification/statistics/views/route_goals_in_week.dart';
 import 'package:priobike/home/models/shortcut.dart';
-import 'package:priobike/home/models/shortcut_route.dart';
 import 'package:priobike/home/services/shortcuts.dart';
 import 'package:priobike/home/views/shortcuts/pictogram.dart';
 import 'package:priobike/main.dart';


### PR DESCRIPTION
There was a bug which would only show RouteShortcuts but not LocationShortcuts in Gamification. This bug is now fixed. 