### PR TITLE
Upgrade sensors_plus and fix IMU caches

### DIFF
--- a/lib/tracking/services/tracking.dart
+++ b/lib/tracking/services/tracking.dart
@@ -228,9 +228,9 @@ class Tracking with ChangeNotifier {
       await savePreviousTracks();
       // Start collecting data to the files of the track.
       await startCollectingGPSData();
-      await startCollectingAccData(accelerometerEvents);
-      await startCollectingGyrData(gyroscopeEvents);
-      await startCollectingMagData(magnetometerEvents);
+      await startCollectingAccData();
+      await startCollectingGyrData();
+      await startCollectingMagData();
       if (sensorSamplingTimer == null || !sensorSamplingTimer!.isActive) {
         sensorSamplingTimer = Timer.periodic(const Duration(seconds: 1), (timer) async => await sampleSensorData());
       }
@@ -282,11 +282,13 @@ class Tracking with ChangeNotifier {
   }
 
   /// Start collecting accelerometer data.
-  Future<void> startCollectingAccData(Stream<AccelerometerEvent> stream) async {
+  Future<void> startCollectingAccData() async {
+    const samplingPeriod = Duration(milliseconds: 1000);
+    final stream = accelerometerEventStream(samplingPeriod: samplingPeriod);
     accCache = CSVCache(
       header: "timestamp,x,y,z",
       file: await track!.accelerometerCSVFile,
-      maxLines: 500, // Flush after 500 lines of data (~5s on most devices).
+      maxLines: 5, // Flush after 5 lines of data (~5s).
     );
     accSub = stream.listen((event) {
       latestAccEventTimestamp = DateTime.now().millisecondsSinceEpoch;
@@ -304,11 +306,13 @@ class Tracking with ChangeNotifier {
   }
 
   /// Start collecting gyroscope data.
-  Future<void> startCollectingGyrData(Stream<GyroscopeEvent> stream) async {
+  Future<void> startCollectingGyrData() async {
+    const samplingPeriod = Duration(milliseconds: 1000);
+    final stream = gyroscopeEventStream(samplingPeriod: samplingPeriod);
     gyrCache = CSVCache(
       header: "timestamp,x,y,z",
       file: await track!.gyroscopeCSVFile,
-      maxLines: 500, // Flush after 500 lines of data (~5s on most devices).
+      maxLines: 5, // Flush after 5 lines of data (~5s).
     );
     gyrSub = stream.listen((event) {
       latestGyroEventTimestamp = DateTime.now().millisecondsSinceEpoch;
@@ -326,11 +330,13 @@ class Tracking with ChangeNotifier {
   }
 
   /// Start collecting magnetometer data.
-  Future<void> startCollectingMagData(Stream<MagnetometerEvent> stream) async {
+  Future<void> startCollectingMagData() async {
+    const samplingPeriod = Duration(milliseconds: 1000);
+    final stream = magnetometerEventStream(samplingPeriod: samplingPeriod);
     magCache = CSVCache(
       header: "timestamp,x,y,z",
       file: await track!.magnetometerCSVFile,
-      maxLines: 500, // Flush after 500 lines of data (~5s on most devices).
+      maxLines: 5, // Flush after 5 lines of data (~5s).
     );
     magSub = stream.listen((event) {
       latestMagEventTimestamp = DateTime.now().millisecondsSinceEpoch;

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -987,20 +987,19 @@ packages:
   sensors_plus:
     dependency: "direct main"
     description:
-      path: "packages/sensors_plus/sensors_plus"
-      ref: main
-      resolved-ref: "8d2dc9a7bb66616c63e8d8cca2833d48724fd76a"
-      url: "https://github.com/priobike/priobike-plus-plugins"
-    source: git
-    version: "2.0.2"
+      name: sensors_plus
+      sha256: "8e7fa79b4940442bb595bfc0ee9da4af5a22a0fe6ebacc74998245ee9496a82d"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.0.2"
   sensors_plus_platform_interface:
     dependency: transitive
     description:
       name: sensors_plus_platform_interface
-      sha256: "95f0cc08791b8bf0c41c5fa99c84be2a7d5bf60a811ddc17e1438b1e68caf0d3"
+      sha256: bc472d6cfd622acb4f020e726433ee31788b038056691ba433fec80e448a094f
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.3"
+    version: "1.2.0"
   share_plus:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -47,11 +47,7 @@ dependencies:
   share_plus: ^7.2.1 # Used for debugging to share example requests/responses via e-mail/airdrop
   firebase_core: ^2.23.0 # Used to initialize the connection to Firebase
   firebase_messaging: ^14.7.5 # Used to receive push notifications of news service
-  sensors_plus: # Used to get accelerometer data
-    git:
-      url: https://github.com/priobike/priobike-plus-plugins
-      ref: main
-      path: packages/sensors_plus/sensors_plus
+  sensors_plus: ^4.0.2 # Used to get the IMU data
   flutter_local_notifications: ^16.1.0 # Used to show the push notifications
   mqtt_client: ^10.0.0
   system_info_plus: ^0.0.5 # Used to check the RAM of user device


### PR DESCRIPTION
`sensors_plus` now supports passing the desired update frequency. Thus, I archived https://github.com/priobike/priobike-plus-plugins

Also, I fixed that the IMU CSV caches would only be flushed every 500 samples (which is 500 seconds with 1Hz instead of 5 seconds as initially intended). Seems like an oversight in previous changes.