### PR TITLE
Fix feedback view takes some time to fetch background image.

### DIFF
--- a/lib/common/map/map_projection.dart
+++ b/lib/common/map/map_projection.dart
@@ -35,7 +35,7 @@ class MapboxMapProjection {
   }
 
   /// Calculate a square bounding box using the Mapbox tile projection system (Mercator).
-  static MapboxMapProjectionBoundingBox? mercatorBoundingBox(List<LatLng> coordinates) {
+  static MapboxMapProjectionBoundingBox? mercatorBoundingBox(List<LatLng> coordinates, double padding) {
     double? minLon;
     double? minLat;
     double? maxLon;
@@ -53,7 +53,7 @@ class MapboxMapProjection {
 
     // Calculate the padding for the background image.
     final vectorLength = sqrt(pow(maxLon - minLon, 2) + pow(maxLat - minLat, 2));
-    final mapPadding = vectorLength * 0.45;
+    final mapPadding = vectorLength * padding;
     minLon -= mapPadding;
     minLat -= mapPadding;
     maxLon += mapPadding;

--- a/lib/home/views/shortcuts/gpx_conversion_waypoints_paint.dart
+++ b/lib/home/views/shortcuts/gpx_conversion_waypoints_paint.dart
@@ -56,7 +56,7 @@ class GPXConversionWaypointsPaintState extends State<GPXConversionWaypointsPaint
   @override
   Widget build(BuildContext context) {
     MapboxMapProjectionBoundingBox? bbox =
-        MapboxMapProjection.mercatorBoundingBox(widget.wpts.map((e) => LatLng(e.lat!, e.lon!)).toList());
+        MapboxMapProjection.mercatorBoundingBox(widget.wpts.map((e) => LatLng(e.lat!, e.lon!)).toList(), 0.45);
     return CustomPaint(
       painter: WaypointsPainter(wpts: widget.wpts, color: widget.gpxColor, bbox: bbox),
       child: CustomPaint(painter: WaypointsPainter(wpts: recWpts, color: widget.approxColor, bbox: bbox)),
@@ -82,7 +82,7 @@ class WaypointsPainter extends CustomPainter {
     final waypoints = wpts;
     final waypointCount = waypoints.length;
 
-    bbox ??= MapboxMapProjection.mercatorBoundingBox(waypoints.map((e) => LatLng(e.lat!, e.lon!)).toList());
+    bbox ??= MapboxMapProjection.mercatorBoundingBox(waypoints.map((e) => LatLng(e.lat!, e.lon!)).toList(), 0.45);
 
     List<double> distances = [];
     double maxDistance = 0.0;

--- a/lib/home/views/shortcuts/gpx_conversion_waypoints_pictogram.dart
+++ b/lib/home/views/shortcuts/gpx_conversion_waypoints_pictogram.dart
@@ -59,10 +59,8 @@ class GpxConversionWaypointsPictogramState extends State<GpxConversionWaypointsP
     List<LatLng> coords;
     List<Wpt> wpts = widget.wpts;
     coords = wpts.map((Wpt e) => LatLng(e.lat!, e.lon!)).toList();
-    backgroundImageFuture = MapboxTileImageCache.requestTile(
-      coords: coords,
-      brightness: fetchedBrightness,
-    ).then((value) {
+    backgroundImageFuture =
+        MapboxTileImageCache.requestTile(coords: coords, brightness: fetchedBrightness, mapPadding: 0.45).then((value) {
       if (!mounted) return;
       if (value == null) return;
       final brightnessNow = Theme.of(context).brightness;

--- a/lib/home/views/shortcuts/pictogram.dart
+++ b/lib/home/views/shortcuts/pictogram.dart
@@ -71,6 +71,7 @@ class ShortcutPictogramState extends State<ShortcutPictogram> {
     backgroundImageFuture = MapboxTileImageCache.requestTile(
       coords: coords,
       brightness: fetchedBrightness,
+      mapPadding: 0.45,
     ).then((value) {
       if (!mounted) return;
       if (value == null) return;
@@ -174,7 +175,7 @@ class ShortcutRoutePainter extends CustomPainter {
     final waypoints = shortcut.waypoints;
     final waypointCount = waypoints.length;
 
-    final bbox = MapboxMapProjection.mercatorBoundingBox(waypoints.map((e) => LatLng(e.lat, e.lon)).toList());
+    final bbox = MapboxMapProjection.mercatorBoundingBox(waypoints.map((e) => LatLng(e.lat, e.lon)).toList(), 0.45);
     if (bbox == null) return;
 
     List<double> distances = [];

--- a/lib/routing/views/layers.dart
+++ b/lib/routing/views/layers.dart
@@ -59,10 +59,8 @@ class LayerSelectionViewState extends State<LayerSelectionView> {
       final styleUri = Theme.of(context).brightness == Brightness.light ? design.lightStyle : design.darkStyle;
 
       final future = MapboxTileImageCache.requestTile(
-        coords: coords,
-        brightness: Theme.of(context).brightness,
-        styleUri: styleUri,
-      ).then((image) {
+              coords: coords, brightness: Theme.of(context).brightness, styleUri: styleUri, mapPadding: 0.45)
+          .then((image) {
         if (image == null) return;
         setState(() {
           screenshots[design] = image;

--- a/lib/tracking/views/track_history_item.dart
+++ b/lib/tracking/views/track_history_item.dart
@@ -308,8 +308,11 @@ class TrackHistoryItemDetailViewState extends State<TrackHistoryItemDetailView> 
                   destinationImage: widget.destinationImage,
                   iconSize: 16,
                   lineWidth: 6,
-                  imageWidthRatio: (widget.width ?? MediaQuery.of(context).size.width) /
-                      (widget.height ?? MediaQuery.of(context).size.height),
+                  // Note: in the feedback view the background image map (1000x1000 pixel) is displayed in full height.
+                  // Therefore the track pictogram needs to be extended outside the screen (logically).
+                  // So we calculate, how much the height is greater then the width.
+                  // This means the ratio is height / width.
+                  imageHeightRatio: MediaQuery.of(context).size.height / MediaQuery.of(context).size.width,
                   mapboxTop: MediaQuery.of(context).padding.top + 96,
                   mapboxRight: 20,
                   mapboxWidth: 64,


### PR DESCRIPTION
Fixes the loading time of the background map in the feedback view. Now only 1 image(1000x1000) will be fetched. The bounding box padding is adjusted to the device's screen size. Therefore we can display the 1000x1000 image with fit to height and still display the whole track on the screen. All other views stay the same, besides using a slightly smaller padding than before (0.45 to mostly 0.6). Current tracks have to be fetched once again and can then be loaded from the cache with the new bounding box padding. 0.45 as map padding is added in other views using the modified function. So Other parts of the app stay as they are. 

This also solves a bug that occurs when the user clicks "fertig" faster then the second image got fetched.

