### PR TITLE
Fix device pixel ratio considered twice for map icons

### DIFF
--- a/lib/ride/views/map.dart
+++ b/lib/ride/views/map.dart
@@ -371,7 +371,6 @@ class RideMapViewState extends State<RideMapView> {
   /// A callback which is executed when the map style was loaded.
   Future<void> onStyleLoaded(mapbox.StyleLoadedEventData styleLoadedEventData) async {
     if (mapController == null || !mounted) return;
-    final ppi = MediaQuery.of(context).devicePixelRatio;
     final isDark = Theme.of(context).brightness == Brightness.dark;
 
     await getFirstLabelLayer();
@@ -388,33 +387,33 @@ class RideMapViewState extends State<RideMapView> {
     if (!mounted) return;
     await DiscomfortsLayer(isDark).install(
       mapController!,
-      iconSize: ppi / 14,
+      iconSize: 0.2,
       at: index,
       showLabels: false,
     );
     index = await getIndex(WaypointsLayer.layerId);
     if (!mounted) return;
-    await WaypointsLayer().install(mapController!, iconSize: ppi / 8, at: index);
+    await WaypointsLayer().install(mapController!, iconSize: 0.33, at: index);
     index = await getIndex(TrafficLightsLayer.layerId);
     if (!mounted) return;
     await TrafficLightsLayer(isDark, hideBehindPosition: true).install(
       mapController!,
-      iconSize: ppi / 5,
+      iconSize: 0.5,
       at: index,
     );
     index = await getIndex(TrafficLightsLayer.layerId);
     if (!mounted) return;
     await TrafficLightsLayerClickable(isDark, hideBehindPosition: true).install(
       mapController!,
-      iconSize: ppi / 5,
+      iconSize: 0.5,
       at: index,
     );
     index = await getIndex(OfflineCrossingsLayer.layerId);
     if (!mounted) return;
-    await OfflineCrossingsLayer(isDark, hideBehindPosition: true).install(mapController!, iconSize: ppi / 5, at: index);
+    await OfflineCrossingsLayer(isDark, hideBehindPosition: true).install(mapController!, iconSize: 0.5, at: index);
     index = await getIndex(TrafficLightLayer.layerId);
     if (!mounted) return;
-    await TrafficLightLayer(isDark).install(mapController!, iconSize: ppi / 5, at: index);
+    await TrafficLightLayer(isDark).install(mapController!, iconSize: 0.5, at: index);
 
     onRoutingUpdate();
     onPositioningUpdate();

--- a/lib/routing/views/map.dart
+++ b/lib/routing/views/map.dart
@@ -500,20 +500,19 @@ class RoutingMapViewState extends State<RoutingMapView> with TickerProviderState
   /// Load all route map layers.
   loadRouteMapLayers() async {
     if (mapController == null) return;
-    final ppi = MediaQuery.of(context).devicePixelRatio;
     final isDark = Theme.of(context).brightness == Brightness.dark;
     var index = await getIndex(OfflineCrossingsLayer.layerId);
     if (!mounted) return;
     await OfflineCrossingsLayer(isDark).install(
       mapController!,
-      iconSize: ppi / 10,
+      iconSize: 0.33,
       at: index,
     );
     index = await getIndex(TrafficLightsLayer.layerId);
     if (!mounted) return;
     await TrafficLightsLayer(isDark).install(
       mapController!,
-      iconSize: ppi / 10,
+      iconSize: 0.33,
       at: index,
     );
     index = await getIndex(WaypointsLayer.layerId);
@@ -527,7 +526,7 @@ class RoutingMapViewState extends State<RoutingMapView> with TickerProviderState
     if (!mounted) return;
     await DiscomfortsLayer(isDark).install(
       mapController!,
-      iconSize: ppi / 14,
+      iconSize: 0.2,
       at: index,
     );
     index = await getIndex(SelectedRouteLayer.layerId);


### PR DESCRIPTION
Device pixel ratio is considered in mapbox itself. Therefore we have to remove it.