### PR TITLE
Fix Feedback view

### DIFF
--- a/lib/feedback/views/main.dart
+++ b/lib/feedback/views/main.dart
@@ -154,6 +154,8 @@ class FeedbackViewState extends State<FeedbackView> {
       brightness: Theme.of(context).brightness,
       systemNavigationBarIconBrightness: Brightness.light,
       child: Scaffold(
+        // To avoid recalculating the map and its painting when the keyboard appears.
+        resizeToAvoidBottomInset: false,
         body: Stack(
           children: [
             SizedBox(


### PR DESCRIPTION
Set resize false to prevent recalculating the map in the feedback view when the keyboard appears.

Was this the problem @PhilippMatthes ?