### PR TITLE
Fix status warning color

### DIFF
--- a/lib/status/views/status.dart
+++ b/lib/status/views/status.dart
@@ -162,7 +162,7 @@ class StatusViewState extends State<StatusView> {
                         ),
                       ),
                       Opacity(
-                        opacity: 0.2,
+                        opacity: isProblem ? 0.6 : 0.2,
                         child: Icon(
                           Icons.chevron_right_rounded,
                           color: isProblem ? Colors.white : CI.radkulturGreen,


### PR DESCRIPTION
Before: ![flutter_02](https://github.com/priobike/priobike-flutter-app/assets/33689888/b5c6843a-9ad0-4141-8133-225588b24606)


After:
![flutter_01](https://github.com/priobike/priobike-flutter-app/assets/33689888/99d76722-0021-486e-9551-53511a757975)
