### PR TITLE
Make non critical service non-blocking in loader view

### DIFF
--- a/lib/settings/views/internal.dart
+++ b/lib/settings/views/internal.dart
@@ -89,6 +89,7 @@ class InternalSettingsViewState extends State<InternalSettingsView> {
     predictionStatusSummary.addListener(update);
     loadStatus = getIt<LoadStatus>();
     statusHistory = getIt<StatusHistory>();
+    statusHistory.fetch();
     statusHistory.addListener(update);
     shortcuts = getIt<Shortcuts>();
     shortcuts.addListener(update);


### PR DESCRIPTION
Ticket: https://trello.com/c/LqbOmE4e/800-%C3%BCberpr%C3%BCfen-dass-ein-ausfall-von-monitoring-services-der-monitoring-vm-nicht-zum-aussperren-aus-der-app-f%C3%BChren