### PR TITLE
Rework SG status text in routing bottom sheet

### DIFF
--- a/lib/routing/views/main.dart
+++ b/lib/routing/views/main.dart
@@ -379,7 +379,7 @@ class RoutingViewState extends State<RoutingView> {
               child: Align(
                 alignment: Alignment.bottomCenter,
                 child: Padding(
-                  padding: EdgeInsets.only(bottom: 132),
+                  padding: EdgeInsets.only(bottom: 144),
                   child: ShortcutsRow(),
                 ),
               ),

--- a/lib/routing/views/map.dart
+++ b/lib/routing/views/map.dart
@@ -702,7 +702,7 @@ class RoutingMapViewState extends State<RoutingMapView> with TickerProviderState
     final frame = MediaQuery.of(context);
     final sheetHeightAbs = sheetHeightRelative == null
         // Bottom padding + sheet init size + padding + shortcut height + padding.
-        ? 124.0 + 8 + 40 + 8 // Default value.
+        ? 136.0 + 8 + 40 + 8 // Default value.
         // Bottom padding + sheet relative size + padding + shortcut height + padding.
         : sheetHeightRelative * frame.size.height + 40 + 8;
     final maxBottomInset = frame.size.height - frame.padding.top - 100;
@@ -718,7 +718,7 @@ class RoutingMapViewState extends State<RoutingMapView> with TickerProviderState
       ),
     );
     // Bottom padding + sheet init size + padding + shortcut height + padding.
-    const attributionMargins = math.Point(10, 124 + 8 + 40 + 8);
+    const attributionMargins = math.Point(10, 136 + 8 + 40 + 8);
     mapController!.attribution.updateSettings(AttributionSettings(
         marginBottom: attributionMargins.y.toDouble(),
         marginRight: attributionMargins.x.toDouble(),
@@ -765,7 +765,7 @@ class RoutingMapViewState extends State<RoutingMapView> with TickerProviderState
     final routeLabelMarginRight = frame.size.width - frame.size.width * routeLabelScreenMarginHorizontal;
     final routeLabelMarginTop = frame.padding.top;
     // Fit initial bottom sheet size of 128px.
-    final routeLabelMarginBottom = frame.size.height - 128;
+    final routeLabelMarginBottom = frame.size.height - 140;
     final widthMid = frame.size.width / 2;
     final heightMid = frame.size.height / 2;
     routeLabelManager = RouteLabelManager(
@@ -1364,8 +1364,8 @@ class RoutingMapViewState extends State<RoutingMapView> with TickerProviderState
             child: Stack(
               children: [
                 Positioned(
-                  left: tapPosition!.dx - animation.value * 128 - 12,
-                  top: tapPosition!.dy - animation.value * 128 - 12,
+                  left: tapPosition!.dx - animation.value * 140 - 12,
+                  top: tapPosition!.dy - animation.value * 140 - 12,
                   child: Opacity(
                     opacity: math.max(0, math.min(1, (animation.value) * 4)),
                     child: Container(
@@ -1438,7 +1438,7 @@ class RoutingMapViewState extends State<RoutingMapView> with TickerProviderState
             children: [
               Positioned(
                 left: 0,
-                top: MediaQuery.of(context).size.height - MediaQuery.of(context).padding.bottom - 270,
+                top: MediaQuery.of(context).size.height - MediaQuery.of(context).padding.bottom - 282,
                 child: SizedBox(
                   width: MediaQuery.of(context).size.width,
                   child: Column(

--- a/lib/routing/views/sheet.dart
+++ b/lib/routing/views/sheet.dart
@@ -178,9 +178,12 @@ class RouteDetailsBottomSheetState extends State<RouteDetailsBottomSheet> {
     final int allTrafficLights = status.ok + status.bad + status.offline;
 
     String textTrafficLights;
+    double percentageTrafficLights = 0;
+
     if (allTrafficLights > 0) {
       textTrafficLights =
           "$allTrafficLights Ampeln angebunden, $okTrafficLights davon haben Geschwindigkeitsempfehlungen";
+      percentageTrafficLights = okTrafficLights / allTrafficLights;
     } else {
       textTrafficLights = "Es befinden sich keine Ampeln auf der Route";
     }
@@ -196,15 +199,43 @@ class RouteDetailsBottomSheetState extends State<RouteDetailsBottomSheet> {
                   "${routing.selectedRoute!.timeText} - ${routing.selectedRoute!.arrivalTimeText}, ${routing.selectedRoute!.lengthText}",
               context: context),
           const SizedBox(height: 2),
-          Container(
-            constraints: BoxConstraints(maxWidth: MediaQuery.of(context).size.width * 0.85),
-            child: Small(
-              text: textTrafficLights,
-              context: context,
-              textAlign: TextAlign.center,
+          Row(mainAxisAlignment: MainAxisAlignment.center, crossAxisAlignment: CrossAxisAlignment.center, children: [
+            Container(
+              constraints: BoxConstraints(maxWidth: MediaQuery.of(context).size.width * 0.65),
+              child: Small(
+                text: textTrafficLights,
+                context: context,
+                textAlign: TextAlign.center,
+                height: 1.1,
+              ),
             ),
-          ),
-          const SizedBox(height: 2),
+            const SmallHSpace(),
+            SizedBox(
+              width: 18,
+              height: 18,
+              child: Stack(
+                alignment: Alignment.center,
+                children: [
+                  CircularProgressIndicator(
+                    value: percentageTrafficLights,
+                    strokeWidth: 4,
+                    backgroundColor: allTrafficLights > 0
+                        ? CI.radkulturGreen.withOpacity(0.2)
+                        : Theme.of(context).colorScheme.onTertiary,
+                    valueColor: const AlwaysStoppedAnimation<Color>(CI.radkulturGreen),
+                  ),
+                  Icon(
+                    Icons.chevron_right_rounded,
+                    color: percentageTrafficLights > 0
+                        ? CI.radkulturGreen.withOpacity(percentageTrafficLights)
+                        : Theme.of(context).colorScheme.onTertiary,
+                    size: 18,
+                  ),
+                ],
+              ),
+            ),
+          ]),
+          const SmallVSpace(),
         ]),
       ]),
     );
@@ -218,9 +249,9 @@ class RouteDetailsBottomSheetState extends State<RouteDetailsBottomSheet> {
       height: frame.size.height, // Needed for reorderable list.
       child: Stack(children: [
         DraggableScrollableSheet(
-          initialChildSize: 128 / frame.size.height + (frame.padding.bottom / frame.size.height),
+          initialChildSize: 140 / frame.size.height + (frame.padding.bottom / frame.size.height),
           maxChildSize: 1,
-          minChildSize: 128 / frame.size.height + (frame.padding.bottom / frame.size.height),
+          minChildSize: 140 / frame.size.height + (frame.padding.bottom / frame.size.height),
           builder: (BuildContext context, ScrollController controller) {
             return Container(
               decoration: BoxDecoration(


### PR DESCRIPTION
Had to remove the percentage circle because there was no space for it since the text wraps around 2 lines now.

Not 100% happy with how it looks right now. It's a lot of text at the top. Do you have any ideas? @PaulPickhardt 