### PR TITLE
Hide traffic light touch indicators in routing view

### DIFF
--- a/lib/common/map/layers/sg_layers.dart
+++ b/lib/common/map/layers/sg_layers.dart
@@ -63,7 +63,7 @@ class TrafficLightsLayer {
   }
 
   /// Install the overlay on the map controller.
-  Future<void> install(mapbox.MapboxMap mapController, {iconSize = 1.0, at = 0}) async {
+  Future<void> install(mapbox.MapboxMap mapController, {iconSize = 1.0, at = 0, showTouchIndicator = false}) async {
     final sourceExists = await mapController.style.styleSourceExists(sourceId);
     if (!sourceExists) {
       await mapController.style.addSource(
@@ -127,53 +127,55 @@ class TrafficLightsLayer {
           ]));
     }
 
-    final trafficLightTouchIndicatorsLayerExists = await mapController.style.styleLayerExists(touchIndicatorsLayerId);
-    if (!trafficLightTouchIndicatorsLayerExists) {
-      await mapController.style.addLayerAt(
-          mapbox.SymbolLayer(
-            sourceId: sourceId,
-            id: touchIndicatorsLayerId,
-            iconSize: iconSize,
-            iconAllowOverlap: true,
-            textAllowOverlap: true,
-            textIgnorePlacement: true,
-            iconOpacity: 0,
-          ),
-          mapbox.LayerPosition(at: at));
-      await mapController.style.setStyleLayerProperty(
-          touchIndicatorsLayerId,
-          'icon-image',
-          json.encode([
-            "case",
-            ["get", "isDark"],
-            "trafficlighttouchindicatordark",
-            "trafficlighttouchindicatorlight",
-          ]));
-      await mapController.style.setStyleLayerProperty(
-          touchIndicatorsLayerId,
-          'icon-opacity',
-          json.encode(
-            showAfter(zoom: 16, opacity: [
+    if (showTouchIndicator) {
+      final trafficLightTouchIndicatorsLayerExists = await mapController.style.styleLayerExists(touchIndicatorsLayerId);
+      if (!trafficLightTouchIndicatorsLayerExists) {
+        await mapController.style.addLayerAt(
+            mapbox.SymbolLayer(
+              sourceId: sourceId,
+              id: touchIndicatorsLayerId,
+              iconSize: iconSize,
+              iconAllowOverlap: true,
+              textAllowOverlap: true,
+              textIgnorePlacement: true,
+              iconOpacity: 0,
+            ),
+            mapbox.LayerPosition(at: at));
+        await mapController.style.setStyleLayerProperty(
+            touchIndicatorsLayerId,
+            'icon-image',
+            json.encode([
               "case",
-              ["get", "showTouchIndicators"],
-              [
+              ["get", "isDark"],
+              "trafficlighttouchindicatordark",
+              "trafficlighttouchindicatorlight",
+            ]));
+        await mapController.style.setStyleLayerProperty(
+            touchIndicatorsLayerId,
+            'icon-opacity',
+            json.encode(
+              showAfter(zoom: 16, opacity: [
                 "case",
-                ["get", "hideBehindPosition"],
+                ["get", "showTouchIndicators"],
                 [
                   "case",
+                  ["get", "hideBehindPosition"],
                   [
-                    "<=",
-                    ["get", "distanceToSgOnRoute"],
-                    -5,
+                    "case",
+                    [
+                      "<=",
+                      ["get", "distanceToSgOnRoute"],
+                      -5,
+                    ],
+                    0.4,
+                    1
                   ],
-                  0.4,
-                  1
+                  1,
                 ],
-                1,
-              ],
-              0
-            ]),
-          ));
+                0
+              ]),
+            ));
+      }
     }
   }
 

--- a/lib/ride/views/map.dart
+++ b/lib/ride/views/map.dart
@@ -389,6 +389,7 @@ class RideMapViewState extends State<RideMapView> {
       mapController!,
       iconSize: 0.5,
       at: index,
+      showTouchIndicator: true,
     );
     index = await getIndex(TrafficLightsLayer.layerId);
     if (!mounted) return;


### PR DESCRIPTION
Ticket: https://trello.com/c/QGRX8neW/815-ampeln-in-der-routingview-haben-touch-indikatoren-obwohl-man-sie-nicht-anklicken-kann-sollten-entfernt-werden