### PR TITLE
Fix redundant push bike segments by dont adding empty features to geojson source

### DIFF
--- a/lib/common/map/layers/route_layers.dart
+++ b/lib/common/map/layers/route_layers.dart
@@ -210,7 +210,9 @@ class RoutePushBikeLayer {
             }
           }
 
-          features.add(feature);
+          // If the current segment is already included in another feature, there are zero coordinates in the feature.
+          // Thus, we don't add it to the features list.
+          if (feature["geometry"]["coordinates"].length >= 2) features.add(feature);
         }
       }
     }


### PR DESCRIPTION
## If available, link to the Trello ticket

[Ticket](https://trello.com/c/iTMwetS6/843-pushbike-layer-pr%C3%BCfen)

## QA Checklist

### Author

- [x] Code Review
- [x] Functionality Tested (iOS and Android + different screens)
- [x] Light/Dark Mode Tested
- [x] Performance/Energy Consumption Tested (especially in ride view)

### Reviewer

- [x] Code Review
- [x] Functionality Tested (iOS and Android + different screens)
- [x] Light/Dark Mode Tested
- [ ] Performance/Energy Consumption Tested (especially in ride view)
