### PR TITLE
Fix speed zero crash on iOS

### DIFF
--- a/lib/positioning/sources/mock.dart
+++ b/lib/positioning/sources/mock.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'dart:convert';
+import 'dart:math';
 
 import 'package:flutter/services.dart';
 import 'package:geolocator/geolocator.dart';
@@ -324,8 +325,9 @@ class PathMockPositionSource extends PositionSource {
         return;
       }
 
-      final bearing = vincenty.bearing(from, to); // [-180°, 180°]
-      final currentLocation = vincenty.offset(from, distanceOnSegment, bearing);
+      final random = Random(); // Simulate GPS inaccuracy.
+      final bearing = vincenty.bearing(from, to) - 2.5 + 5 * random.nextDouble(); // [-180°, 180°]
+      final currentLocation = vincenty.offset(from, distanceOnSegment - 1 + 2 * random.nextDouble(), bearing);
       final heading = bearing > 0 ? bearing : 360 + bearing;
 
       lastPosition = Position(

--- a/lib/ride/views/speedometer/speed_arc.dart
+++ b/lib/ride/views/speedometer/speed_arc.dart
@@ -4,15 +4,17 @@ import 'package:flutter/material.dart';
 
 class SpeedometerSpeedArcPainter extends CustomPainter {
   final double pct;
-  final double lastPct;
   final bool isDark;
   final bool batterySaveMode;
 
+  /// The last percentage value of the speedometer arc. Only made for battery save mode.
+  final double? lastPct;
+
   SpeedometerSpeedArcPainter({
     required pct,
-    required this.lastPct,
     required this.isDark,
     required this.batterySaveMode,
+    this.lastPct,
   }) : pct = pct == 0 ? 0.001 : pct;
 
   /// Paints the tail of the pointer
@@ -48,6 +50,7 @@ class SpeedometerSpeedArcPainter extends CustomPainter {
   }
 
   void paintSpeedArcTailBatterySave(Canvas canvas, Size size) {
+    if (lastPct == null) return;
     if (pct == lastPct) return;
     // Scale the opacity of the glow based on the speed.
     final center = Offset(size.width / 2, size.height / 2);
@@ -56,7 +59,7 @@ class SpeedometerSpeedArcPainter extends CustomPainter {
     const endAngle = pi / 4;
 
     final angle = startAngle + pct * (endAngle - startAngle);
-    final lastAngle = startAngle + lastPct * (endAngle - startAngle);
+    final lastAngle = startAngle + lastPct! * (endAngle - startAngle);
 
     final colors = [
       Colors.white.withOpacity(0.0),
@@ -72,10 +75,10 @@ class SpeedometerSpeedArcPainter extends CustomPainter {
     const diff = 0.75;
 
     // Calculate borders for the sweep gradient.
-    final minBorder = pct < lastPct ? (pct - 0.001) * diff : (lastPct - 0.001) * diff;
-    final min = pct < lastPct ? (pct) * diff : (lastPct) * diff;
-    final max = pct > lastPct ? (pct) * diff : (lastPct) * diff;
-    final maxBorder = pct > lastPct ? (pct + 0.001) * diff : (lastPct + 0.001) * diff;
+    final minBorder = pct < lastPct! ? (pct - 0.001) * diff : (lastPct! - 0.001) * diff;
+    final min = pct < lastPct! ? pct * diff : lastPct! * diff;
+    final max = pct > lastPct! ? pct * diff : lastPct! * diff;
+    final maxBorder = pct > lastPct! ? (pct + 0.001) * diff : (lastPct! + 0.001) * diff;
 
     () {
       final rect = Rect.fromCircle(center: center, radius: radius);

--- a/lib/ride/views/speedometer/view.dart
+++ b/lib/ride/views/speedometer/view.dart
@@ -63,40 +63,41 @@ class RideSpeedometerViewState extends State<RideSpeedometerView>
   /// The current gauge stops, if we have the necessary data.
   List<double> gaugeStops = [0.0, 1.0];
 
-  /// The animation controller for the speed animation.
-  late AnimationController speedAnimationController;
+  /// The animation controller for the speed animation. Only used if battery save mode is disabled.
+  AnimationController? speedAnimationController;
 
-  /// The speed animation.
-  late Animation<double> speedAnimation;
+  /// The speed animation. Only used if battery save mode is disabled.
+  Animation<double>? speedAnimation;
 
   /// The current percentage of the speed in the speedometer.
   double speedAnimationPct = 0.0;
 
-  /// The last percentage of the speed in the speedometer.
-  double lastSpeedAnimationPct = 0.0;
+  /// The current speed.
+  double speed = 0.0;
+
+  /// The last percentage of the speed in the speedometer. Only used in battery save mode.
+  double? lastSpeedAnimationPct;
 
   /// Update the speedometer.
-  void updateSpeedometer() {
-    // Animate the speed to the new value.
-    final kmh = (positioning.lastPosition?.speed ?? 0.0 / maxSpeed) * 3.6;
-    final newSpeedAnimationPct = (kmh - minSpeed) / (maxSpeed - minSpeed);
-
-    // Only update on changes.
-    // Use animation if not in save battery mode.
-    if (lastSpeedAnimationPct != newSpeedAnimationPct && !settings.saveBatteryModeEnabled) {
-      speedAnimationController.animateTo(newSpeedAnimationPct,
-          duration: const Duration(milliseconds: 1000), curve: Curves.easeInOut);
+  void updateSpeedometerWithAnimation(double kmh) {
+    // Don't animate the speed if it is the same.
+    if (kmh == speed) {
+      return;
     }
+    speed = kmh;
+    final newSpeedAnimationPct = (kmh - minSpeed) / (maxSpeed - minSpeed);
+    speedAnimationController?.animateTo(newSpeedAnimationPct,
+        duration: const Duration(milliseconds: 1000), curve: Curves.easeInOut);
+  }
 
+  /// Update the speedometer.
+  void updateSpeedometerWithoutAnimation(double kmh) {
+    final newSpeedAnimationPct = (kmh - minSpeed) / (maxSpeed - minSpeed);
+    // Update always required to update the tail accordingly.
     setState(() {
       lastSpeedAnimationPct = speedAnimationPct;
       speedAnimationPct = newSpeedAnimationPct;
     });
-
-    // Load the gauge colors and steps, from the predictor.
-    if (!routing.hadErrorDuringFetch) {
-      loadGauge(ride);
-    }
   }
 
   /// Update the layout of the speedometer.
@@ -104,23 +105,25 @@ class RideSpeedometerViewState extends State<RideSpeedometerView>
     setState(() {});
   }
 
+  void updateSpeedometer() {
+    // Load the gauge colors and steps.
+    if (!routing.hadErrorDuringFetch) {
+      loadGauge();
+    }
+
+    final kmh = (positioning.lastPosition?.speed ?? 0.0 / maxSpeed) * 3.6;
+
+    if (settings.saveBatteryModeEnabled) {
+      updateSpeedometerWithoutAnimation(kmh);
+    } else {
+      updateSpeedometerWithAnimation(kmh);
+    }
+  }
+
   @override
   void initState() {
     hideNavigationBarAndroid();
     super.initState();
-    // Initialize the speed animation.
-    speedAnimationController = AnimationController(
-      vsync: this,
-      duration: const Duration(milliseconds: 1000),
-      animationBehavior: AnimationBehavior.preserve,
-    );
-    speedAnimation = Tween<double>(begin: 0.0, end: 1.0).animate(speedAnimationController);
-    speedAnimation.addListener(() {
-      setState(() {
-        speedAnimationPct = speedAnimation.value;
-      });
-    });
-
     settings = getIt<Settings>();
     positioning = getIt<Positioning>();
     positioning.addListener(updateSpeedometer);
@@ -128,6 +131,21 @@ class RideSpeedometerViewState extends State<RideSpeedometerView>
     routing.addListener(updateLayout);
     ride = getIt<Ride>();
     ride.addListener(updateLayout);
+
+    if (!settings.saveBatteryModeEnabled) {
+      // Initialize the speed animation.
+      speedAnimationController = AnimationController(
+        vsync: this,
+        duration: const Duration(milliseconds: 1000),
+        animationBehavior: AnimationBehavior.preserve,
+      );
+      speedAnimation = Tween<double>(begin: 0.0, end: 1.0).animate(speedAnimationController!);
+      speedAnimation!.addListener(() {
+        setState(() {
+          speedAnimationPct = speedAnimation!.value;
+        });
+      });
+    }
 
     // Fetch the maximum speed from the settings service.
     maxSpeed = settings.speedMode.maxSpeed;
@@ -145,7 +163,7 @@ class RideSpeedometerViewState extends State<RideSpeedometerView>
 
   @override
   void dispose() {
-    speedAnimationController.dispose();
+    speedAnimationController?.dispose();
     positioning.removeListener(updateSpeedometer);
     routing.removeListener(updateLayout);
     ride.removeListener(updateLayout);
@@ -164,7 +182,7 @@ class RideSpeedometerViewState extends State<RideSpeedometerView>
   }
 
   /// Load the gauge colors and steps, from the predictor.
-  void loadGauge(Ride ride) {
+  void loadGauge() {
     if (ride.predictionProvider?.recommendation == null || ride.calcDistanceToNextSG == null) {
       gaugeColors = [defaultGaugeColor, defaultGaugeColor];
       gaugeStops = [0.0, 1.0];
@@ -426,7 +444,7 @@ class RideSpeedometerViewState extends State<RideSpeedometerView>
                       Padding(
                         padding: const EdgeInsets.only(bottom: 26),
                         child: Text(
-                          '${speedkmh.toStringAsFixed(3)} km/h',
+                          '${speedkmh.toStringAsFixed(settings.isIncreasedSpeedPrecisionInSpeedometerEnabled ? 3 : 0)} km/h',
                           style: const TextStyle(
                             color: Colors.white,
                             fontSize: 28,

--- a/lib/settings/services/settings.dart
+++ b/lib/settings/services/settings.dart
@@ -92,6 +92,9 @@ class Settings with ChangeNotifier {
   /// If the filter for the free ride view is enabled.
   bool isFreeRideFilterEnabled;
 
+  /// If we want to show the speed with increased precision in the speedometer.
+  bool isIncreasedSpeedPrecisionInSpeedometerEnabled = false;
+
   static const enablePerformanceOverlayKey = "priobike.settings.enablePerformanceOverlay";
   static const defaultEnablePerformanceOverlay = false;
 
@@ -443,6 +446,27 @@ class Settings with ChangeNotifier {
     return success;
   }
 
+  static const isIncreasedSpeedPrecisionInSpeedometerEnabledKey =
+      "priobike.settings.isIncreasedSpeedPrecisionInSpeedometerEnabled";
+  static const defaultIsIncreasedSpeedPrecisionInSpeedometerEnabled = false;
+
+  Future<bool> setIncreasedSpeedPrecisionInSpeedometerEnabled(bool isIncreasedSpeedPrecisionInSpeedometerEnabled,
+      [SharedPreferences? storage]) async {
+    storage ??= await SharedPreferences.getInstance();
+    final prev = this.isIncreasedSpeedPrecisionInSpeedometerEnabled;
+    this.isIncreasedSpeedPrecisionInSpeedometerEnabled = isIncreasedSpeedPrecisionInSpeedometerEnabled;
+    final bool success = await storage.setBool(
+        isIncreasedSpeedPrecisionInSpeedometerEnabledKey, isIncreasedSpeedPrecisionInSpeedometerEnabled);
+    if (!success) {
+      log.e(
+          "Failed to set isIncreasedSpeedPrecisionInSpeedometerEnabled to $isIncreasedSpeedPrecisionInSpeedometerEnabled");
+      this.isIncreasedSpeedPrecisionInSpeedometerEnabled = prev;
+    } else {
+      notifyListeners();
+    }
+    return success;
+  }
+
   Settings(
     this.backend, {
     this.enablePerformanceOverlay = defaultEnablePerformanceOverlay,
@@ -464,6 +488,7 @@ class Settings with ChangeNotifier {
     this.didMigrateBackgroundImages = defaultDidMigrateBackgroundImages,
     this.enableSimulatorMode = defaultSimulatorMode,
     this.isFreeRideFilterEnabled = defaultIsFreeRideFilterEnabled,
+    this.isIncreasedSpeedPrecisionInSpeedometerEnabled = defaultIsIncreasedSpeedPrecisionInSpeedometerEnabled,
   });
 
   /// Load the internal settings from the shared preferences.
@@ -503,6 +528,13 @@ class Settings with ChangeNotifier {
     }
     try {
       isFreeRideFilterEnabled = storage.getBool(isFreeRideFilterEnabledKey) ?? defaultIsFreeRideFilterEnabled;
+    } catch (e) {
+      /* Do nothing and use the default value given by the constructor. */
+    }
+    try {
+      isIncreasedSpeedPrecisionInSpeedometerEnabled =
+          storage.getBool(isIncreasedSpeedPrecisionInSpeedometerEnabledKey) ??
+              defaultIsIncreasedSpeedPrecisionInSpeedometerEnabled;
     } catch (e) {
       /* Do nothing and use the default value given by the constructor. */
     }

--- a/lib/settings/views/internal.dart
+++ b/lib/settings/views/internal.dart
@@ -265,6 +265,17 @@ class InternalSettingsViewState extends State<InternalSettingsView> {
                 Padding(
                   padding: const EdgeInsets.only(top: 8),
                   child: SettingsElement(
+                    title: "Erhöhte Genauigkeit der Geschwindigkeit im Tacho",
+                    icon: settings.isIncreasedSpeedPrecisionInSpeedometerEnabled
+                        ? Icons.check_box
+                        : Icons.check_box_outline_blank,
+                    callback: () => settings.setIncreasedSpeedPrecisionInSpeedometerEnabled(
+                        !settings.isIncreasedSpeedPrecisionInSpeedometerEnabled),
+                  ),
+                ),
+                Padding(
+                  padding: const EdgeInsets.only(top: 8),
+                  child: SettingsElement(
                     title: "Ort",
                     subtitle: settings.backend.region,
                     icon: Icons.expand_more,


### PR DESCRIPTION
## If available, link to the Trello ticket

/

On iOS our app crashed when we reached 0.000 kmh speed. We fixed this and also added the possibility to monitor the current speed with a higher precision.

## QA Checklist

### Author

- [x] Code Review
- [x] Functionality Tested (iOS and Android + different screens)
- [x] Light/Dark Mode Tested
- [x] Performance/Energy Consumption Tested (especially in ride view)

### Reviewer

- [ ] Code Review
- [ ] Functionality Tested (iOS and Android + different screens)
- [ ] Light/Dark Mode Tested
- [ ] Performance/Energy Consumption Tested (especially in ride view)
