### PR TITLE
Bump android compiled version to 34

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -34,7 +34,7 @@ apply plugin: 'kotlin-android'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-    compileSdkVersion 33
+    compileSdkVersion 34
 
     dependencies {
         implementation 'com.android.support:multidex:1.0.3'
@@ -55,8 +55,8 @@ android {
 
     defaultConfig {
         applicationId "de.tudresden.priobike"
-        minSdkVersion 21
-        targetSdkVersion 33
+        minSdkVersion 24
+        targetSdkVersion 34
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
     }


### PR DESCRIPTION
## If available, link to the Trello ticket

[Ticket](https://trello.com/c/C8rsIAYL/853-android-compile-version-updaten)

Also increments minSDKVersion to 24 (Android 7)
There is currently one user still on android 7 (beta). Android 9 is the minimum in Release. So I guess it's okay to increase minSDKVersion.

## QA Checklist

### Author

- [ ] Code Review
- [ ] Functionality Tested (iOS and Android + different screens)
- [ ] Light/Dark Mode Tested
- [ ] Performance/Energy Consumption Tested (especially in ride view)

### Reviewer

- [ ] Code Review
- [ ] Functionality Tested (iOS and Android + different screens)
- [ ] Light/Dark Mode Tested
- [ ] Performance/Energy Consumption Tested (especially in ride view)
