### PR TITLE
Correctly get base64 from import link (base64 can include '/')

### DIFF
--- a/lib/home/models/shortcut.dart
+++ b/lib/home/models/shortcut.dart
@@ -53,7 +53,7 @@ abstract class Shortcut {
       longLink ??= link;
 
       // Create a new shortcut from the long link.
-      final subUrls = longLink.split('/');
+      final subUrls = longLink.split('/import/');
       final shortcutBase64 = subUrls.last;
       final shortcutBytes = base64.decode(shortcutBase64);
       final shortcutUTF8 = utf8.decode(shortcutBytes);


### PR DESCRIPTION
## If available, link to the Trello ticket

Fixes import of many QR codes/short links where the base64 contains a `/`. Before only the part after the `/` got taken for base64 decoding.

## QA Checklist

### Author

- [ ] Code Review
- [ ] Functionality Tested (iOS and Android + different screens)
- [ ] Light/Dark Mode Tested
- [ ] Performance/Energy Consumption Tested (especially in ride view)

### Reviewer

- [ ] Code Review
- [ ] Functionality Tested (iOS and Android + different screens)
- [ ] Light/Dark Mode Tested
- [ ] Performance/Energy Consumption Tested (especially in ride view)
