### PR TITLE
Make optional route attributes non blocking + Don't load optional attributes after reroutes during the ride

### DIFF
--- a/lib/ride/views/main.dart
+++ b/lib/ride/views/main.dart
@@ -121,7 +121,7 @@ class RideViewState extends State<RideView> {
               // Use a timed lock to avoid rapid refreshing of routes.
               lock.run(() async {
                 await routing.selectRemainingWaypoints();
-                final routes = await routing.loadRoutes();
+                final routes = await routing.loadRoutes(fetchOptionalData: false);
 
                 if (routes == null || routes.isEmpty) {
                   // If we have no routes (e.g. because of routing error or because the user left the city boundaries),

--- a/lib/routing/views/sheet.dart
+++ b/lib/routing/views/sheet.dart
@@ -10,8 +10,8 @@ import 'package:priobike/positioning/services/positioning.dart';
 import 'package:priobike/routing/models/waypoint.dart';
 import 'package:priobike/routing/services/map_functions.dart';
 import 'package:priobike/routing/services/routing.dart';
-import 'package:priobike/routing/views/details/poi.dart';
 import 'package:priobike/routing/views/details/height.dart';
+import 'package:priobike/routing/views/details/poi.dart';
 import 'package:priobike/routing/views/details/road.dart';
 import 'package:priobike/routing/views/details/surface.dart';
 import 'package:priobike/routing/views/details/waypoints.dart';
@@ -338,7 +338,11 @@ class RouteDetailsBottomSheetState extends State<RouteDetailsBottomSheet> {
                 child: Column(
                   children: [
                     renderDragIndicator(context),
-                    if (!bottomSheetIsReady) const LoadingIcon(),
+                    if (!bottomSheetIsReady)
+                      const SizedBox(
+                        height: 32,
+                        child: LoadingIcon(),
+                      ),
                     AnimatedOpacity(
                       duration: const Duration(milliseconds: 1000),
                       curve: Curves.easeInOutCubic,


### PR DESCRIPTION
## If available, link to the Trello ticket

[Ticket](https://trello.com/c/81y9Esq8/911-laden-der-pois-in-der-routing-view-sollte-non-blocking-sein-keine-anzeigen-wenn-es-keine-gibt)

## QA Checklist

### Author

- [x] Code Review
- [x] Functionality Tested (iOS and Android + different screens)
- [ ] Light/Dark Mode Tested
- [ ] Performance/Energy Consumption Tested (especially in ride view)

### Reviewer

- [x] Code Review
- [x] Functionality Tested (iOS and Android + different screens)
- [x] Light/Dark Mode Tested
- [ ] Performance/Energy Consumption Tested (especially in ride view)
