### PR TITLE
Cap speed pct at 1 (prevents overflow of speedometer arc)

### DIFF
--- a/lib/ride/views/speedometer/speed_arc.dart
+++ b/lib/ride/views/speedometer/speed_arc.dart
@@ -15,7 +15,11 @@ class SpeedometerSpeedArcPainter extends CustomPainter {
     required this.isDark,
     required this.batterySaveMode,
     this.lastPct,
-  }) : pct = pct == 0 ? 0.001 : pct;
+  }) : pct = pct == 0 // Don't allow 0, because the gradient starts at 0 and if the speed is 0 as well, we get an error.
+            ? 0.001
+            : pct > 1 // Cap the percentage value at 1.
+                ? 1
+                : pct;
 
   /// Paints the tail of the pointer
   void paintSpeedArcTail(Canvas canvas, Size size) {


### PR DESCRIPTION
## If available, link to the Trello ticket

[Ticket](https://trello.com/c/Vycx1c0o/904-tacho-nadel-ist-nicht-limitiert)

## QA Checklist

### Author

- [x] Code Review
- [x] Functionality Tested (iOS and Android + different screens)
- [x] Light/Dark Mode Tested
- [x] Performance/Energy Consumption Tested (especially in ride view)

### Reviewer

- [x] Code Review
- [ ] Functionality Tested (iOS and Android + different screens)
- [ ] Light/Dark Mode Tested
- [ ] Performance/Energy Consumption Tested (especially in ride view)
