### PR TITLE
Remove unnecessary displayCurrentUserLocation call

### DIFF
--- a/lib/routing/views/map.dart
+++ b/lib/routing/views/map.dart
@@ -203,7 +203,6 @@ class RoutingMapViewState extends State<RoutingMapView> with TickerProviderState
   /// Updates the centering.
   updateMapFunctions() async {
     if (widget.mapFunctions.needsCentering) {
-      displayCurrentUserLocation();
       fitCameraToUserPosition();
       widget.mapFunctions.needsCentering = false;
       return;


### PR DESCRIPTION
## If available, link to the ticket

Closes: #593

It was never an issue. But still removed an unnecessary call like we discussed @adeveloper-wq.

## QA Checklist

### Author

- [x] Code Review
- [x] Functionality Tested (iOS and Android + different screens)
- [ ] Light/Dark Mode Tested
- [ ] Performance/Energy Consumption Tested (especially in ride view)

### Reviewer

- [x] Code Review
- [ ] Functionality Tested (iOS and Android + different screens)
- [ ] Light/Dark Mode Tested
- [ ] Performance/Energy Consumption Tested (especially in ride view)
