### PR TITLE
Fix selected sg jumps to early by correcting the distances on route

### DIFF
--- a/lib/routing/models/route.dart
+++ b/lib/routing/models/route.dart
@@ -243,13 +243,15 @@ class Route {
         last == null ? null : vincenty.distance(LatLng(last.lat, last.lon), LatLng(endpoint.lat, endpoint.lon));
 
     // The distance to the first waypoints needs to be added to the signal group distances to calculate correct distances on route.
-    for (var i = 0; i < signalGroupsDistancesOnRoute.length; i++) {
-      signalGroupsDistancesOnRoute[i] += distToFirst ?? 0;
-    }
+    if (distToFirst != null) {
+      for (var i = 0; i < signalGroupsDistancesOnRoute.length; i++) {
+        signalGroupsDistancesOnRoute[i] += distToFirst;
+      }
 
-    // Also add the start distance for crossing distances on route.
-    for (var i = 0; i < crossingsDistancesOnRoute.length; i++) {
-      crossingsDistancesOnRoute[i] += distToFirst ?? 0;
+      // Also add the start distance for crossing distances on route.
+      for (var i = 0; i < crossingsDistancesOnRoute.length; i++) {
+        crossingsDistancesOnRoute[i] += distToFirst;
+      }
     }
 
     return Route(

--- a/lib/routing/models/route.dart
+++ b/lib/routing/models/route.dart
@@ -241,6 +241,17 @@ class Route {
     final last = route.isNotEmpty ? route.last : null;
     final distToLast =
         last == null ? null : vincenty.distance(LatLng(last.lat, last.lon), LatLng(endpoint.lat, endpoint.lon));
+
+    // The distance to the first waypoints needs to be added to the signal group distances to calculate correct distances on route.
+    for (var i = 0; i < signalGroupsDistancesOnRoute.length; i++) {
+      signalGroupsDistancesOnRoute[i] += distToFirst ?? 0;
+    }
+
+    // Also add the start distance for crossing distances on route.
+    for (var i = 0; i < crossingsDistancesOnRoute.length; i++) {
+      crossingsDistancesOnRoute[i] += distToFirst ?? 0;
+    }
+
     return Route(
       idx: idx,
       path: path,


### PR DESCRIPTION
## If available, link to the ticket

Bug reported by user. The selected traffic light jumps to the next traffic light when the user is close to the current traffic light. This was due to the missing distance added when the first waypoint was not on a route segment.

Closes: \#

## QA Checklist

### Author

- [x] Code Review
- [x] Functionality Tested (iOS and Android + different screens)
- [ ] Light/Dark Mode Tested
- [ ] Performance/Energy Consumption Tested (especially in ride view)

### Reviewer

- [x] Code Review
- [ ] Functionality Tested (iOS and Android + different screens)
- [ ] Light/Dark Mode Tested
- [ ] Performance/Energy Consumption Tested (especially in ride view)
